### PR TITLE
Implement start_watching_film and schema change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,49 @@
-# filmbot for Discord
+# A FilmBot for Discord
 
 Discord Bot to manage our Film Club.
 
 ## Scripts
 
 There are 2 separate scripts:
-
   * [`register_application_commands.py`](register_application_commands/register_application_commands.py) needs to be run any time the [Discord application commands](https://discord.com/developers/docs/interactions/application-commands) changes
   * [`lambda_function.py`](discord_handler/lambda_function.py) is run any time an application command is run
+
+## Table Schema
+
+There is one DynamoDB table needed by FilmBot called "filmbot-table".  It has a partition key 
+called "PK" and a sort key called "SK".
+
+The partition key will be Discord Guild ID.
+
+The sort key will take one of the following forms:
+  1. `"USER." + DiscordUserID`
+  2. `"FILM.NOMINATED." + FilmID`
+  3. `"FILM.WATCHED." + DateTimeStarted + "." + FilmID`
+
+Where:
+  * `DiscordUserID` is the user's Discord ID (supplied by Discord)
+  * `FilmID` is a UUID that we generate per film
+  * `DateStarted` is an ISO 8601 formatted string of the UTC datetime that
+     film was started being watched
+
+For example:
+  1. `"USER.16393729388392"`
+  2. `"FILM.NOMINATED.76988c8a-a15d-48a9-8805-5c7f1723e298"`
+  3. `"FILM.WATCHED.2022-01-19T21:35:58Z.76988c8a-a15d-48a9-8805-5c7f1723e298"`
+
+### "USER.*" Record Format
+
+The records with sort key starting with `"USER.*"` contains the following
+fields:
+  * `NominatedFilmID` is a string matching a `"FILM.NOMINATED.*"` sort key that represents this users nominated film, or `NULL` if this user has no currently nominated film
+  * `VoteID` is a string matching a `"FILM.NOMINATED.*"` sort key that represents this user's voted film, or `NULL` if this user has not voted yet in this round
+  * `AttendanceVoteID` is a string matching a `"FILM.WATCHED.*.*"` sort key that represents this user's attendance vote for the last watched film, or `NULL` if this user did not watch the latest film
+
+### "FILM.*" Record Format
+
+The records with sort key starting with `"FILM.*"` contains the following fields:
+  * `FilmName` is a string representation of the film's name
+  * `DiscordUserID` is a string matching the users's Discord ID who nominated this film
+  * `CastVotes` is a non-negative integer representing the number of votes cast for this film
+  * `AttendanceVotes` is a non-negative integer representing the number of attendance votes for this film
+  * `DateNominated` is an ISO 8601 formatting string of the UTC datetime this film was nominated

--- a/discord_handler/UserError.py
+++ b/discord_handler/UserError.py
@@ -1,5 +1,7 @@
 class UserError(RuntimeError):
-    """Exception raised when a user makes an error.
-    A `UserError`'s exception message should be displayed to the user."""
+    """
+    Exception raised when a user makes an error.
+    A `UserError`'s exception message should be displayed to the user.
+    """
 
     pass

--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -1,59 +1,37 @@
-import boto3
+from pprint import pprint
 from enum import Enum
 from UserError import UserError
+from datetime import date, timedelta, datetime
 
-MEMBERS_TABLE = "filmbot-members"
-# filmbot-members
-# ---------------
-# This table is a list of all users who are members of the Film Club.  It is keyed by
-# each user's Discord user ID.
-#
-#   +---------------------+---------+----------------------------+
-#   | field name          | type    | notes                      |
-#   +---------------------+---------+----------------------------+
-#   | discord-user-id*    | string  |                            |
-#   | date-joined         | date    |                            |
-#   | nominated-film-id   | ?string | key of filmbot-nominations |
-#   | vote-id             | ?string | key of filmbot-votes       |
-#   | attendance-vote-id  | ?string | key of filmbot-votes       |
-#   +---------------------+---------+----------------------------+
-#
+TABLE_NAME = "FilmBotTable"
 
-NOMINATIONS_TABLE = "filmbot-nominations"
-# filmbot-nominations
-# -------------------
-# This table is a list of all nominated films, their details, and the number of current votes.
-#
-#   +------------------+---------+
-#   | field name       | type    |
-#   +------------------+---------+
-#   | film-id*         | string  |
-#   | imdb-film-id     | ?string |
-#   | film-title       | string  |
-#   | film-genre       | ?string |
-#   | discord-user-id  | string  |
-#   | cast-votes       | integer |
-#   | attendance-votes | integer |
-#   | date-nominated   | date    |
-#   | date-watched     | ?date   |
-#   +------------------+---------+
-#
+USER_PK = "PK"
+USER_SK = "SK"
+USER_NominatedFilmID = "NominatedFilmID"
+USER_VoteID = "VoteID"
+USER_AttendanceVoteID = "AttendanceVoteID"
 
-VOTES_TABLE = "filmbot-votes"
-# filmbot-votes
-# -------------
-# This film is a list of all votes cast by users, either explicitly or by attendance.
-#
-#   +------------------+---------+----------------------------+
-#   | field name       | type    | notes                      |
-#   +------------------+---------+----------------------------+
-#   | vote-id*         | string  | UUID                       |
-#   | film-id          | string  | key of filmbot-nominations |
-#   | discord-user-id  | string  |                            |
-#   | type             | integer | 0=vote 1=attendance        |
-#   | date-cast        | date    |                            |
-#   +------------------+---------+----------------------------+
-#
+
+FILM_PK = "PK"
+FILM_SK = "SK"
+FILM_FilmName = "FilmName"
+FILM_DiscordUserID = "DiscordUserID"
+FILM_CastVotes = "CastVotes"
+FILM_AttendanceVotes = "AttendanceVotes"
+FILM_DateNominated = "DateNominated"
+
+
+def extract_SK(sortKeyValue):
+    return sortKeyValue.split(".")[-1]
+
+
+def extract_watched(sortKeyValue):
+    FILM, WATCHED, watch_time, film_id = sortKeyValue.split(".")
+    assert FILM == "FILM"
+    assert WATCHED == "WATCHED"
+    return watch_time, film_id
+
+
 def keyed(v):
     """Convert the specified `v` into a dict keyed by the type, that will be accepted by DynamoDB"""
     if isinstance(v, bool):
@@ -65,27 +43,37 @@ def keyed(v):
     elif v is None:
         return {"NULL": True}
     else:
-        assert False, "'" + v + "' is not an accepted input for 'keyed'"
+        assert False, f"'{v}' is not an accepted input for 'keyed'"
+
+
+def key_map(map):
+    """Unkey the value for every element of the specified `map`."""
+    result = {}
+    for key in map:
+        result[key] = keyed(map[key])
+    return result
 
 
 def unkeyed(v):
     """Convert the specified `v` from DynamoDB's dict keyed by the type to
     a primitive Python type."""
-    for typeName in v:
-        value = v[typeName]
-        if typeName == "BOOL":
+    for type_name in v:
+        value = v[type_name]
+        if type_name == "BOOL":
             return value
-        if typeName == "S":
+        if type_name == "S":
             return value
-        elif typeName == "N":
+        elif type_name == "N":
             return int(value)
-        elif typeName == "NULL":
+        elif type_name == "NULL":
             return None
         else:
-            assert False, "'" + typeName + "' is not an understood type for 'unkeyed'"
+            assert (
+                False
+            ), f"'{type_name}' is not an understood type for 'unkeyed'"
 
 
-def liftOutTypes(map):
+def unkey_map(map):
     """Unkey the value for every element of the specified `map`."""
     result = {}
     for key in map:
@@ -99,45 +87,48 @@ class VotingStatus(Enum):
 
 
 class FilmBot:
-    def __init__(self, dynamodb, dynamodb_client):
-        self._members_table = dynamodb.Table(MEMBERS_TABLE)
-        self._nominations_table = dynamodb.Table(NOMINATIONS_TABLE)
-        self._vote_table = dynamodb.Table(VOTES_TABLE)
-        self._dynamodb_client = dynamodb_client
-
-    @property
-    def members_table(self):
-        return self._members_table
-
-    @property
-    def nominations_table(self):
-        return self._nominations_table
-
-    @property
-    def votes_table(self):
-        return self._votes_table
+    def __init__(self, DynamoDBClient, GuildID):
+        self._dynamodb_client = DynamoDBClient
+        self._guildID = GuildID
 
     @property
     def client(self):
         return self._dynamodb_client
 
+    @property
+    def guildID(self):
+        return self._guildID
+
     def get_users(self):
-        """Return a dictionary keyed by users against their votes, nominations, etc."""
-        scan_kwargs = {
-            "Select": "ALL_ATTRIBUTES",
-            "ReturnConsumedCapacity": "NONE",
+        """
+        Return a dictionary keyed by users against their votes and nomination.
+        """
+
+        kwargs = {
+            "TableName": TABLE_NAME,
+            "ExpressionAttributeValues": {
+                ":GuildID": {"S": self.guildID},
+                ":UserPrefix": {"S": "USER."},
+            },
+            "KeyConditionExpression": (
+                f"{USER_PK} = :GuildID AND "
+                f"begins_with({USER_SK}, :UserPrefix)"
+            ),
         }
 
-        members_table = self.members_table
         done = False
         start_key = None
         users = {}
         while not done:
             if start_key:
-                scan_kwargs["ExclusiveStartKey"] = start_key
-            response = members_table.scan(**scan_kwargs)
+                kwargs["ExclusiveStartKey"] = start_key
+            response = self.client.query(**kwargs)
             for user in response.get("Items"):
-                users[user["discord-user-id"]] = user
+                fixed_user = unkey_map(user)
+                user_id = extract_SK(fixed_user[USER_SK])
+                del fixed_user[USER_PK]
+                del fixed_user[USER_SK]
+                users[user_id] = fixed_user
             start_key = response.get("LastEvaluatedKey", None)
             done = start_key is None
 
@@ -147,119 +138,171 @@ class FilmBot:
         """Return an array of currently nominated films in the order that they should
         be watched based on their vote tally."""
 
-        film_ids = list(
-            map(
-                lambda n: {"film-id": {"S": n["nominated-film-id"]}},
-                filter(lambda n: n["nominated-film-id"], self.get_users().values()),
-            )
-        )
-
-        response = self.client.batch_get_item(
-            RequestItems={
-                NOMINATIONS_TABLE: {"Keys": film_ids, "ConsistentRead": True}
+        kwargs = {
+            "TableName": TABLE_NAME,
+            "ExpressionAttributeValues": {
+                ":GuildID": {"S": self.guildID},
+                ":FilmPrefix": {"S": "FILM.NOMINATED."},
             },
-            ReturnConsumedCapacity="NONE",
-        )
+            "KeyConditionExpression": (
+                f"{FILM_PK} = :GuildID AND "
+                f"begins_with({FILM_SK}, :FilmPrefix)"
+            ),
+        }
 
-        cleaned = map(liftOutTypes, response["Responses"][NOMINATIONS_TABLE])
+        done = False
+        start_key = None
+        nominated = []
+        while not done:
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            response = self.client.query(**kwargs)
+            for film in response.get("Items"):
+                fixed_film = unkey_map(film)
+                fixed_film["FilmID"] = extract_SK(fixed_film[FILM_SK])
+                del fixed_film[FILM_PK]
+                nominated.append(fixed_film)
+            start_key = response.get("LastEvaluatedKey", None)
+            done = start_key is None
+
+        # Sort by:
+        #   - the highest number of votes
+        #   - if that is the same, then tie break by highest cast votes
+        #   - if that is the same, then tie break by earliest nominated
         return sorted(
-            cleaned, reverse=True, key=lambda n: n["cast-votes"] + n["attendance-votes"]
+            nominated,
+            key=lambda n: [
+                -n[FILM_CastVotes] - n[FILM_AttendanceVotes],
+                -n[FILM_CastVotes],
+                n[FILM_DateNominated],
+            ],
         )
 
-    def register_user(self, discord_user_id, datetime):
-        """Attempt to register the specified `discord_user_id` at the specified `datetime`.
-        If `discord_user_id` is already registered, then throw an exception."""
-        try:
-            self.members_table.put_item(
-                Item={
-                    "discord-user-id": discord_user_id,
-                    "date-joined": datetime.isoformat(),
-                    "nominated-film-id": None,
-                    "vote-id": None,
-                    "attendance-vote-id": None,
-                },
-                ConditionExpression="attribute_not_exists(discord-user-id)",
-            )
-        except self.client.exceptions.ConditionalCheckFailedException as e:
-            raise UserError("User is already registered")
+    def get_all_films(self):
+        """
+        Return an array watched and unwatched films in the order that they were
+        nominated.
+        """
+        kwargs = {
+            "TableName": TABLE_NAME,
+            "ExpressionAttributeValues": {
+                ":GuildID": {"S": self.guildID},
+                ":FilmPrefix": {"S": "FILM."},
+            },
+            "KeyConditionExpression": (
+                f"{FILM_PK} = :GuildID AND "
+                f"begins_with({FILM_SK}, :FilmPrefix)"
+            ),
+        }
+
+        done = False
+        start_key = None
+        films = []
+        while not done:
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            response = self.client.query(**kwargs)
+            for film in response.get("Items"):
+                fixed_film = unkey_map(film)
+                film_id = extract_SK(fixed_film[FILM_SK])
+                del fixed_film[FILM_PK]
+                films.append(fixed_film)
+            start_key = response.get("LastEvaluatedKey", None)
+            done = start_key is None
+
+        return sorted(films, key=lambda n: n[FILM_DateNominated])
 
     def nominate_film(self, *, DiscordUserID, FilmName, NewFilmID, DateTime):
-        """Attempt to nominate the specified `FilmName` as the film choice for the specified `DiscordUserID`.
-        If `DiscordUserID` is not a registered user, or `DiscordUserID` already has a nomination then throw an exception."""
+        """
+        Attempt to nominate the specified `FilmName` as the film choice for the
+        specified `DiscordUserID`.  If `DiscordUserID` is not a registered user
+        then register them.  If `DiscordUserID` already has a nomination then
+        throw an exception.
+        """
 
         try:
             self.client.transact_write_items(
                 TransactItems=[
                     {
                         "Update": {
-                            "TableName": MEMBERS_TABLE,
-                            "Key": {"discord-user-id": {"S": DiscordUserID}},
+                            "TableName": TABLE_NAME,
+                            "Key": {
+                                USER_PK: {"S": self.guildID},
+                                USER_SK: {"S": f"USER.{DiscordUserID}"},
+                            },
                             "ExpressionAttributeValues": {
-                                ":new_film_id": {"S": NewFilmID},
-                                ":null": {"NULL": True},
+                                ":NewFilmID": {"S": NewFilmID},
+                                ":Null": {"NULL": True},
                             },
-                            "ExpressionAttributeNames": {
-                                "#nominated": "nominated-film-id",
-                                "#discord-user-id": "discord-user-id",
-                            },
-                            "ConditionExpression": "attribute_exists(#discord-user-id) AND #nominated = :null",
-                            "UpdateExpression": "SET #nominated = :new_film_id",
+                            "ConditionExpression": (
+                                f"attribute_not_exists({USER_SK}) OR "
+                                f"{USER_NominatedFilmID} = :Null"
+                            ),
+                            # Make sure to null out the other fields in case we didn't have a user yet
+                            # These should both be Null at this point as we can only nominate after we
+                            # watch a film and these are cleared
+                            "UpdateExpression": (
+                                f"SET {USER_NominatedFilmID} = :NewFilmID "
+                                f"SET {USER_VoteID} = :Null "
+                                f"SET {USER_AttendanceVoteID} = :Null"
+                            ),
                         }
                     },
                     {
                         "Put": {
-                            "TableName": NOMINATIONS_TABLE,
+                            "TableName": TABLE_NAME,
                             "Item": {
-                                "film-id": {"S": NewFilmID},
-                                "imdb-film-id": {"NULL": True},
-                                "film-title": {"S": FilmName},
-                                "film-genre": {"NULL": True},
-                                "discord-user-id": {"S": DiscordUserID},
-                                "cast-votes": {"N": "0"},
-                                "attendance-votes": {"N": "0"},
-                                "date-nominated": {"S": DateTime.isoformat()},
-                                "date-watched": {"NULL": True},
+                                FILM_PK: {"S": self.guildID},
+                                FILM_SK: {"S": f"FILM.NOMINATED.{NewFilmID}"},
+                                FILM_FilmName: {"S": FilmName},
+                                FILM_DiscordUserID: {"S": DiscordUserID},
+                                FILM_CastVotes: {"N": "0"},
+                                FILM_AttendanceVotes: {"N": "0"},
+                                FILM_DateNominated: {
+                                    "S": DateTime.isoformat()
+                                },
                             },
+                            # Make sure we haven't reused this film ID before
+                            "ConditionExpression": f"attribute_not_exists({FILM_SK})",
                         }
                     },
                 ]
             )
         except self.client.exceptions.TransactionCanceledException as e:
-            # Note that we can hit this if the user is not registered too, but all
-            # users in the Discord channel should be registered.  Ideally the
-            # `TransactionCanceledException` would return the existing value in the
-            # database (when setting) `ReturnValuesOnConditionCheckFailure`, but it
-            # only works in the Java SDK.
+            # This can also occur if we pass in a reused FilmID, but that is
+            # impossible if we're using a UUID properly.
             raise UserError(
                 "Unable to nominate a film as you have already nominated one"
             )
 
     def cast_preference_vote(self, *, DiscordUserID, FilmID):
-        """Attempt to cast a vote by the specified `DiscordUserID` for the specified `FilmID` (changing any previously cast vote)
-        If `DiscordUserID` is not a registered user, or `FilmID` refers to your nominated film, or `DiscordUserID` already has a nomination then throw an exception.
-        Return whether the voting is complete"""
+        """
+        Attempt to cast a vote for `FilmID` by `DiscordUserID` and return
+        whether voting is complete.  Throw an exception if either
+        `DiscordUserID` is not a registered user, FilmID` refers to that
+        user's nominated film, or `FilmID` doesn't point to a nominated film.
+        """
 
         users = self.get_users()
         if DiscordUserID not in users:
-            raise UserError("User is not registered")
+            raise UserError("You can't vote until you have nominated a film")
 
         our_user = users[DiscordUserID]
-        previous_vote = our_user["vote-id"]
+        previous_vote = our_user[USER_VoteID]
 
         # Disallow voting for your own nomination
-        if FilmID == our_user["nominated-film-id"]:
-            raise UserError("Cannot vote for your own film")
-
-        # Check everyone has nominated
-        user_list = users.values()
-        everyone_has_nominated = any(u for u in user_list if u["nominated-film-id"])
-        if not everyone_has_nominated:
-            raise UserError("Cannot vote unless all users have nominated")
+        if FilmID == our_user[USER_NominatedFilmID]:
+            raise UserError("You can't vote for your own film")
 
         # Record if this is the last user to vote
-        user_voted_count = sum(user["vote-id"] is not None for user in user_list)
-        our_user_hasnt_voted = our_user["vote-id"] is None
-        is_last_vote = user_voted_count + int(our_user_hasnt_voted) == len(user_list)
+        user_list = users.values()
+        user_voted_count = sum(
+            user[USER_VoteID] is not None for user in user_list
+        )
+        our_user_hasnt_voted = our_user[USER_VoteID] is None
+        is_last_vote = user_voted_count + int(our_user_hasnt_voted) == len(
+            user_list
+        )
 
         # Do nothing if user votes for the same thing
         if previous_vote == FilmID:
@@ -274,34 +317,35 @@ class FilmBot:
             # i.e. there haven't been any changes between our read and this write
             {
                 "Update": {
-                    "TableName": MEMBERS_TABLE,
-                    "Key": {"discord-user-id": {"S": DiscordUserID}},
+                    "TableName": TABLE_NAME,
+                    "Key": {
+                        USER_PK: {"S": self.guildID},
+                        USER_SK: {"S": f"USER.{DiscordUserID}"},
+                    },
                     "ExpressionAttributeValues": {
-                        ":new_vote_id": {"S": FilmID},
-                        ":previous_vote_id": keyed(previous_vote),
+                        ":NewFilmID": {"S": FilmID},
+                        ":PreviousVoteID": keyed(previous_vote),
                     },
-                    "ExpressionAttributeNames": {
-                        "#vote": "vote-id",
-                        "#discord-user-id": "discord-user-id",
-                    },
-                    "ConditionExpression": "attribute_exists(#discord-user-id) AND #vote = :previous_vote_id",
-                    "UpdateExpression": "SET #vote = :new_vote_id",
+                    "ConditionExpression": (
+                        f"attribute_exists({USER_SK}) AND "
+                        f"{USER_VoteID} = :PreviousVoteID"
+                    ),
+                    "UpdateExpression": f"SET {USER_VoteID} = :NewFilmID",
                 }
             },
             # Increment vote count in nominations for new film (also check it exists)
             {
                 "Update": {
-                    "TableName": NOMINATIONS_TABLE,
-                    "Key": {"film-id": {"S": FilmID}},
+                    "TableName": TABLE_NAME,
+                    "Key": {
+                        FILM_PK: {"S": self.guildID},
+                        FILM_SK: {"S": f"FILM.NOMINATED.{FilmID}"},
+                    },
                     "ExpressionAttributeValues": {
-                        ":inc": {"N": "1"},
+                        ":One": {"N": "1"},
                     },
-                    "ExpressionAttributeNames": {
-                        "#cast_votes": "cast-votes",
-                        "#film-id": "film-id",
-                    },
-                    "ConditionExpression": "attribute_exists(#film-id)",
-                    "UpdateExpression": "SET #cast_votes = #cast_votes + :inc",
+                    "ConditionExpression": f"attribute_exists({FILM_SK})",
+                    "UpdateExpression": f"SET {FILM_CastVotes} = {FILM_CastVotes} + :One",
                 }
             },
         ]
@@ -311,17 +355,17 @@ class FilmBot:
             items.append(
                 {
                     "Update": {
-                        "TableName": NOMINATIONS_TABLE,
-                        "Key": {"film-id": {"S": previous_vote}},
-                        "ExpressionAttributeValues": {
-                            ":dec": {"N": "-1"},
+                        "TableName": TABLE_NAME,
+                        "Key": {
+                            FILM_PK: {"S": self.guildID},
+                            FILM_SK: {"S": f"FILM.NOMINATED.{previous_vote}"},
                         },
-                        "ExpressionAttributeNames": {
-                            "#cast_votes": "cast-votes",
+                        "ExpressionAttributeValues": {
+                            ":One": {"N": "1"},
                         },
                         # We don't need a ConditionExpression as we should never be updating
                         # something that wasn't in the table
-                        "UpdateExpression": "SET #cast_votes = #cast_votes + :dec",
+                        "UpdateExpression": f"SET {FILM_CastVotes} = {FILM_CastVotes} - :One",
                     }
                 }
             )
@@ -342,14 +386,110 @@ class FilmBot:
             else VotingStatus.UNCOMPLETE
         )
 
-    def start_watching_film(self, imdb_film_id):
-        # TODO
-        assert False
+    def start_watching_film(self, *, FilmID, DateTime):
+        """
+        Attempt to record that we're watching the specified `FilmID`.
+        Also clear out all cast votes from all users and clear out the
+        user's nomination who had previously nominated `FilmID`.  Throw
+        an exception if `FilmID` isn't correct or less than 24 hours has
+        passed since watching the last film.
+        """
 
-    def record_attendance_vote(self, discord_user_id):
-        # TODO
-        assert False
+        response = self.client.get_item(
+            TableName=TABLE_NAME,
+            Key={
+                FILM_PK: {"S": self.guildID},
+                FILM_SK: {"S": f"FILM.NOMINATED.{FilmID}"},
+            },
+        )
+        if "Item" not in response:
+            raise UserError("Unknown film")
 
-    def stop_recording_attendance(self):
-        # TODO
+        film = response["Item"]
+        user_id = film[FILM_DiscordUserID]["S"]
+
+        # Get the last film watched and see if enough time has passed
+        response = self.client.query(
+            TableName=TABLE_NAME,
+            ExpressionAttributeValues={
+                ":GuildID": {"S": self.guildID},
+                ":WatchedPrefix": {"S": "FILM.WATCHED."},
+            },
+            KeyConditionExpression=(
+                f"{FILM_PK} = :GuildID AND "
+                f"begins_with({FILM_SK}, :WatchedPrefix)"
+            ),
+            ScanIndexForward=False,
+        )
+
+        if response["Items"]:
+            latest_watched_film = response["Items"][0]
+            watch_time, _ = extract_watched(latest_watched_film[FILM_SK]["S"])
+            watch_time = datetime.fromisoformat(watch_time)
+            if DateTime > watch_time + timedelta(days=1):
+                raise UserError(
+                    "At least 24 hours must pass before watching films"
+                )
+
+        # Clear out the cast and attendance votes
+        update_expr = (
+            f"SET {USER_VoteID} = :Null SET {USER_AttendanceVoteID} = :Null"
+        )
+        update_and_clear_expr = (
+            update_expr + f" SET {USER_NominatedFilmID} = :Null"
+        )
+
+        items = list(
+            map(
+                lambda u: {
+                    "Update": {
+                        "TableName": TABLE_NAME,
+                        "Key": {
+                            USER_PK: {"S": self.guildID},
+                            USER_SK: {"S": f"USER.{u[0]}"},
+                        },
+                        "ExpressionAttributeValues": {
+                            ":Null": {"NULL": True},
+                            ":PreviousNomination": {
+                                "S": u[1][USER_NominatedFilmID]
+                            },
+                        },
+                        # No need to check that the user exists
+                        "ConditionExpression": f"{USER_NominatedFilmID} = :PreviousNomination",
+                        "UpdateExpression": (
+                            update_and_clear_expr
+                            if u[0] == user_id
+                            else update_expr
+                        ),
+                    }
+                },
+                self.get_users().items(),
+            )
+        )
+
+        # Delete the film entry and reenter it with the `NOMINATED` prefix + Datetime
+        film[FILM_SK] = {"S": f"FILM.WATCHED.{DateTime.isoformat()}.{FilmID}"}
+        items += [
+            {
+                "Delete": {
+                    "TableName": TABLE_NAME,
+                    "Key": {
+                        FILM_PK: {"S": self.guildID},
+                        FILM_SK: {"S": f"FILM.NOMINATED.{FilmID}"},
+                    },
+                    # Make sure the film still exists to defend against this
+                    # function being called multiple times in quick succession
+                    "ConditionExpression": f"attribute_exists({FILM_SK})",
+                }
+            },
+            {
+                "Put": {
+                    "TableName": TABLE_NAME,
+                    "Item": film,
+                },
+            },
+        ]
+        self.client.transact_write_items(TransactItems=items)
+
+    def record_attendance_vote(self, *, DiscordUserID, DateTime):
         assert False

--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -1,12 +1,85 @@
 import unittest
 import boto3
+from math import factorial
+from itertools import permutations
 from moto import mock_dynamodb2
-from filmbot import FilmBot, MEMBERS_TABLE, NOMINATIONS_TABLE, VOTES_TABLE, VotingStatus
+from filmbot import FilmBot, TABLE_NAME, VotingStatus, unkey_map, key_map
 from datetime import datetime, timedelta
 from uuid import uuid1
 from UserError import UserError
 
 AWS_REGION = "eu-west-2"
+
+
+def grab_db(client):
+    kwargs = {
+        "TableName": TABLE_NAME,
+        "Select": "ALL_ATTRIBUTES",
+        "ReturnConsumedCapacity": "NONE",
+    }
+
+    members_table = client.scan(**kwargs)
+    done = False
+    start_key = None
+    records = {}
+    while not done:
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+        response = client.scan(**kwargs)
+        for record in response.get("Items"):
+            r = unkey_map(record)
+            del r["PK"]
+            records.setdefault(record["PK"]["S"], []).append(r)
+        start_key = response.get("LastEvaluatedKey", None)
+        done = start_key is None
+
+    # Sort by the sort key
+    for key in records:
+        records[key].sort(
+            key=lambda n: n["SK"],
+        )
+
+    return records
+
+
+def set_db(client, data):
+    try:
+        client.delete_table(TableName=TABLE_NAME)
+    except Exception:
+        pass
+
+    client.create_table(
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    if not data:
+        return
+
+    # Add data
+    items = []
+    for guild_id in data:
+        for record in data[guild_id]:
+            keyed = key_map(record)
+            keyed["PK"] = {"S": guild_id}
+            items.append(
+                {
+                    "Put": {
+                        "TableName": TABLE_NAME,
+                        "Item": keyed,
+                    }
+                }
+            )
+
+    client.transact_write_items(TransactItems=items)
 
 
 class TestFilmBot(unittest.TestCase):
@@ -16,41 +89,23 @@ class TestFilmBot(unittest.TestCase):
         """
         Mock `dynamodb2` and create the tables we expect.
         """
+
+        # Set unlimited length for assertEqual diff lengths
+        self.maxDiff = None
+
         self.mock_dynamodb2.start()
         boto3.setup_default_session()
         self.dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
         self.dynamodb_client = boto3.client("dynamodb", region_name=AWS_REGION)
 
-        # Create our 3 expected tables
-        self.dynamodb.create_table(
-            TableName=MEMBERS_TABLE,
-            KeySchema=[{"AttributeName": "discord-user-id", "KeyType": "HASH"}],
-            AttributeDefinitions=[
-                {"AttributeName": "discord-user-id", "AttributeType": "S"}
-            ],
-            BillingMode="PAY_PER_REQUEST",
-        )
-        self.dynamodb.create_table(
-            TableName=NOMINATIONS_TABLE,
-            KeySchema=[{"AttributeName": "film-id", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "film-id", "AttributeType": "S"}],
-            BillingMode="PAY_PER_REQUEST",
-        )
-        self.dynamodb.create_table(
-            TableName=VOTES_TABLE,
-            KeySchema=[{"AttributeName": "vote-id", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "vote-id", "AttributeType": "S"}],
-            BillingMode="PAY_PER_REQUEST",
-        )
+        set_db(self.dynamodb_client, {})
 
         # Check all tables have been created
         self.assertEqual(
             self.dynamodb_client.list_tables()["TableNames"],
-            [MEMBERS_TABLE, NOMINATIONS_TABLE, VOTES_TABLE],
+            [TABLE_NAME],
         )
-
-        # Create our `FilmBot`
-        self.filmbot = FilmBot(self.dynamodb, self.dynamodb_client)
+        self.assertEqual(grab_db(self.dynamodb_client), {})
         pass
 
     def tearDown(self):
@@ -60,204 +115,677 @@ class TestFilmBot(unittest.TestCase):
         self.mock_dynamodb2.stop()
         pass
 
-    def test_register_user(self):
-        """
-        Test `register_user`.
-        """
-
-        # Check we can register users successfully
-        dummy_user_id = "12345"
-        time_registered = datetime(2000, 12, 31, 23, 59, 59, 999999)
-        self.filmbot.register_user(dummy_user_id, time_registered)
-        self.assertEqual(
-            self.dynamodb_client.describe_table(TableName=MEMBERS_TABLE)["Table"][
-                "ItemCount"
-            ],
-            1,
-        )
-
-        table = self.dynamodb.Table(MEMBERS_TABLE)
-        record = table.get_item(Key={"discord-user-id": dummy_user_id})
-        self.assertEqual(
-            record["Item"],
+    def test_get_users(self):
+        guild1 = "guild1"
+        user_id1 = "123"
+        set_db(
+            self.dynamodb_client,
             {
-                "discord-user-id": dummy_user_id,
-                "date-joined": time_registered.isoformat(),
-                "nominated-film-id": None,
-                "vote-id": None,
-                "attendance-vote-id": None,
+                guild1: [
+                    {
+                        "SK": f"USER.{user_id1}",
+                        "NominatedFilmID": None,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    }
+                ]
             },
         )
 
-        # Check registering duplicate Discord IDs throw
-        with self.assertRaises(UserError):
-            self.filmbot.register_user(
-                dummy_user_id, time_registered + timedelta(days=1)
-            )
+        filmbot = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild1)
+        self.assertEqual(
+            filmbot.get_users(),
+            {
+                user_id1: {
+                    "NominatedFilmID": None,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                }
+            },
+        )
+
+        user_id2 = "user2"
+        film_id = "fake-film-id"
+        film_id2 = "fake-film-id2"
+        guild2 = "second-guild"
+        set_db(
+            self.dynamodb_client,
+            {
+                guild1: [
+                    {
+                        "SK": f"USER.{user_id1}",
+                        "NominatedFilmID": film_id,
+                        "VoteID": film_id2,
+                        "AttendanceVoteID": None,
+                    },
+                    {
+                        "SK": f"USER.{user_id2}",
+                        "NominatedFilmID": None,
+                        "VoteID": film_id,
+                        "AttendanceVoteID": film_id2,
+                    },
+                ],
+                guild2: [
+                    {
+                        "SK": f"USER.{user_id1}",
+                        "NominatedFilmID": None,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(
+            filmbot.get_users(),
+            {
+                user_id1: {
+                    "NominatedFilmID": film_id,
+                    "VoteID": film_id2,
+                    "AttendanceVoteID": None,
+                },
+                user_id2: {
+                    "NominatedFilmID": None,
+                    "VoteID": film_id,
+                    "AttendanceVoteID": film_id2,
+                },
+            },
+        )
         pass
 
-    def test_nominate_film(self):
-        dummy_user_id = "12345"
-        time_registered = datetime(2000, 12, 31, 23, 59, 59, 999999)
-        self.filmbot.register_user(dummy_user_id, time_registered)
-        expected_users = {
-            dummy_user_id: {
-                "discord-user-id": dummy_user_id,
-                "date-joined": time_registered.isoformat(),
-                "nominated-film-id": None,
-                "vote-id": None,
-                "attendance-vote-id": None,
+    def test_get_nominations(self):
+        guild = "TEST-GUILD"
+        filmbot = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild)
+
+        # Get that it works with 0 films
+        self.assertEqual(filmbot.get_nominations(), [])
+
+        # Check that it works a few films
+        d = datetime(2001, 1, 1, 5, 0, 0)
+        input_films = [
+            {
+                "SK": "FILM.NOMINATED.film1",
+                "FilmName": "FilmName1",
+                "DiscordUserID": "UserA",
+                "CastVotes": 0,
+                "AttendanceVotes": 7,
+                "DateNominated": d.isoformat(),
             },
-        }
-        self.assertEqual(self.filmbot.get_users(), expected_users)
+            {
+                "SK": "FILM.NOMINATED.film2",
+                "FilmName": "FilmName2",
+                "DiscordUserID": "UserB",
+                "CastVotes": 3,
+                "AttendanceVotes": 3,
+                "DateNominated": d.isoformat(),
+            },
+            {
+                "SK": "FILM.NOMINATED.film3",
+                "FilmName": "FilmName3",
+                "DiscordUserID": "UserC",
+                "CastVotes": 2,
+                "AttendanceVotes": 4,
+                "DateNominated": d.isoformat(),
+            },
+            {
+                "SK": "FILM.NOMINATED.film4",
+                "FilmName": "FilmName4",
+                "DiscordUserID": "UserD",
+                "CastVotes": 2,
+                "AttendanceVotes": 4,
+                "DateNominated": (d + timedelta(seconds=1)).isoformat(),
+            },
+            {
+                "SK": f"FILM.WATCHED.{d.isoformat()}.film5",
+                "FilmName": "FilmName5",
+                "DiscordUserID": "UserE",
+                "CastVotes": 10,
+                "AttendanceVotes": 10,
+                "DateNominated": d.isoformat(),
+            },
+        ]
 
-        film_id = str(uuid1())
-        film_name = "My Film"
-        nominated = datetime(2001, 1, 2, 3, 4, 5)
+        expected = [
+            {
+                "SK": "FILM.NOMINATED.film1",
+                "FilmID": "film1",
+                "FilmName": "FilmName1",
+                "DiscordUserID": "UserA",
+                "CastVotes": 0,
+                "AttendanceVotes": 7,
+                "DateNominated": d.isoformat(),
+            },
+            {
+                "SK": "FILM.NOMINATED.film2",
+                "FilmID": "film2",
+                "FilmName": "FilmName2",
+                "DiscordUserID": "UserB",
+                "CastVotes": 3,
+                "AttendanceVotes": 3,
+                "DateNominated": d.isoformat(),
+            },
+            {
+                "SK": "FILM.NOMINATED.film3",
+                "FilmID": "film3",
+                "FilmName": "FilmName3",
+                "DiscordUserID": "UserC",
+                "CastVotes": 2,
+                "AttendanceVotes": 4,
+                "DateNominated": d.isoformat(),
+            },
+            {
+                "SK": "FILM.NOMINATED.film4",
+                "FilmID": "film4",
+                "FilmName": "FilmName4",
+                "DiscordUserID": "UserD",
+                "CastVotes": 2,
+                "AttendanceVotes": 4,
+                "DateNominated": (d + timedelta(seconds=1)).isoformat(),
+            },
+        ]
 
-        self.filmbot.nominate_film(
-            DiscordUserID=dummy_user_id,
-            FilmName=film_name,
-            NewFilmID=film_id,
-            DateTime=nominated,
+        # Test all permutation of the input to make sure that we are actually
+        # sorting the rows
+        count = 0
+        for input in permutations(input_films):
+            set_db(self.dynamodb_client, {guild: input})
+
+            self.assertEqual(filmbot.get_nominations(), expected)
+            count += 1
+
+        assert count == factorial(len(input_films))
+
+    def test_get_all_films(self):
+        guild = "TEST-GUILD"
+        filmbot = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild)
+
+        # Get that it works with 0 films
+        self.assertEqual(filmbot.get_all_films(), [])
+
+        d = datetime(2001, 1, 1, 5, 0, 0)
+        input_films = [
+            {
+                "SK": "FILM.NOMINATED.film1",
+                "FilmName": "FilmName1",
+                "DiscordUserID": "UserA",
+                "CastVotes": 0,
+                "AttendanceVotes": 7,
+                "DateNominated": d.isoformat(),
+            },
+            {
+                "SK": "FILM.NOMINATED.film2",
+                "FilmName": "FilmName2",
+                "DiscordUserID": "UserB",
+                "CastVotes": 3,
+                "AttendanceVotes": 3,
+                "DateNominated": (d + timedelta(seconds=2)).isoformat(),
+            },
+            {
+                "SK": f"FILM.WATCHED.{(d + timedelta(seconds=1)).isoformat()}.film3",
+                "FilmName": "FilmName3",
+                "DiscordUserID": "UserC",
+                "CastVotes": 2,
+                "AttendanceVotes": 4,
+                "DateNominated": (d + timedelta(seconds=1)).isoformat(),
+            },
+            {
+                "SK": f"FILM.WATCHED.{d.isoformat()}.film4",
+                "FilmName": "FilmName4",
+                "DiscordUserID": "UserD",
+                "CastVotes": 10,
+                "AttendanceVotes": 10,
+                "DateNominated": (d + timedelta(seconds=3)).isoformat(),
+            },
+        ]
+
+        expected = [
+            {
+                "SK": "FILM.NOMINATED.film1",
+                "FilmName": "FilmName1",
+                "DiscordUserID": "UserA",
+                "CastVotes": 0,
+                "AttendanceVotes": 7,
+                "DateNominated": d.isoformat(),
+            },
+            {
+                "SK": f"FILM.WATCHED.{(d + timedelta(seconds=1)).isoformat()}.film3",
+                "FilmName": "FilmName3",
+                "DiscordUserID": "UserC",
+                "CastVotes": 2,
+                "AttendanceVotes": 4,
+                "DateNominated": (d + timedelta(seconds=1)).isoformat(),
+            },
+            {
+                "SK": "FILM.NOMINATED.film2",
+                "FilmName": "FilmName2",
+                "DiscordUserID": "UserB",
+                "CastVotes": 3,
+                "AttendanceVotes": 3,
+                "DateNominated": (d + timedelta(seconds=2)).isoformat(),
+            },
+            {
+                "SK": f"FILM.WATCHED.{d.isoformat()}.film4",
+                "FilmName": "FilmName4",
+                "DiscordUserID": "UserD",
+                "CastVotes": 10,
+                "AttendanceVotes": 10,
+                "DateNominated": (d + timedelta(seconds=3)).isoformat(),
+            },
+        ]
+
+        # Test all permutation of the input to make sure that we are actually
+        # sorting the rows
+        count = 0
+        for input in permutations(input_films):
+            set_db(self.dynamodb_client, {guild: input})
+
+            self.assertEqual(filmbot.get_all_films(), expected)
+            count += 1
+
+        assert count == factorial(len(input_films))
+
+    def test_nominate_film(self):
+        user_id1 = "user1"
+        film_id1 = str(uuid1())
+        film_name1 = "My Film"
+        time1 = datetime(2001, 1, 2, 3, 4, 5)
+
+        guild1 = "GUILD1"
+        filmbot = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild1)
+
+        filmbot.nominate_film(
+            DiscordUserID=user_id1,
+            FilmName=film_name1,
+            NewFilmID=film_id1,
+            DateTime=time1,
         )
 
-        expected_users[dummy_user_id]["nominated-film-id"] = film_id
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-
-        expected_nominations = [
+        self.assertEqual(
+            grab_db(self.dynamodb_client),
             {
-                "film-id": film_id,
-                "imdb-film-id": None,
-                "film-title": film_name,
-                "film-genre": None,
-                "discord-user-id": dummy_user_id,
-                "cast-votes": 0,
-                "attendance-votes": 0,
-                "date-nominated": nominated.isoformat(),
-                "date-watched": None,
-            }
-        ]
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
+                guild1: [
+                    {
+                        "SK": f"FILM.NOMINATED.{film_id1}",
+                        "FilmName": film_name1,
+                        "DiscordUserID": user_id1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "DateNominated": time1.isoformat(),
+                    },
+                    {
+                        "SK": f"USER.{user_id1}",
+                        "NominatedFilmID": film_id1,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                ]
+            },
+        )
 
         # Check nominating fails when you already have a nomination
+        film_name2 = "My Film 2: The Sequel"
         with self.assertRaises(UserError):
-            self.filmbot.nominate_film(
-                DiscordUserID=dummy_user_id,
-                FilmName="My New Film",
-                NewFilmID=str(uuid1()),
-                DateTime=nominated,
+            filmbot.nominate_film(
+                DiscordUserID=user_id1,
+                FilmName=film_name2,
+                NewFilmID=film_id1,
+                DateTime=time1,
             )
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
 
-        # Check nominating fails for a non-registered user
-        with self.assertRaises(UserError):
-            self.filmbot.nominate_film(
-                DiscordUserID="non-existent user",
-                FilmName="My New Film",
-                NewFilmID=str(uuid1()),
-                DateTime=nominated,
-            )
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
-
-        self.filmbot.register_user("123", time_registered)
-        expected_users["123"] = {
-            "discord-user-id": "123",
-            "date-joined": time_registered.isoformat(),
-            "nominated-film-id": None,
-            "vote-id": None,
-            "attendance-vote-id": None,
-        }
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
-
+        user_id2 = "user2"
         film_id2 = str(uuid1())
-        self.filmbot.nominate_film(
-            DiscordUserID="123",
-            FilmName="My New Film",
+        time2 = datetime(2002, 1, 2, 3, 4, 5)
+        filmbot.nominate_film(
+            DiscordUserID=user_id2,
+            FilmName=film_name2,
             NewFilmID=film_id2,
-            DateTime=nominated,
+            DateTime=time2,
         )
 
-        expected_users["123"]["nominated-film-id"] = film_id2
-        expected_nominations.append(
-            {
-                "film-id": film_id2,
-                "imdb-film-id": None,
-                "film-title": "My New Film",
-                "film-genre": None,
-                "discord-user-id": "123",
-                "cast-votes": 0,
-                "attendance-votes": 0,
-                "date-nominated": nominated.isoformat(),
-                "date-watched": None,
-            }
-        )
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
+        expected = {
+            guild1: [
+                {
+                    "SK": f"FILM.NOMINATED.{film_id1}",
+                    "FilmName": film_name1,
+                    "DiscordUserID": user_id1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": time1.isoformat(),
+                },
+                {
+                    "SK": f"FILM.NOMINATED.{film_id2}",
+                    "FilmName": film_name2,
+                    "DiscordUserID": user_id2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": time2.isoformat(),
+                },
+                {
+                    "SK": f"USER.{user_id1}",
+                    "NominatedFilmID": film_id1,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"USER.{user_id2}",
+                    "NominatedFilmID": film_id2,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+            ]
+        }
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check voting for your film is an error
+        # Check we can't reuse film IDs
+        user_id3 = "user3"
+        film_name3 = "My Film 3: The Return of The Unit Test"
         with self.assertRaises(UserError):
-            self.filmbot.cast_preference_vote(
-                DiscordUserID=dummy_user_id, FilmID=film_id
-            ),
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
+            filmbot.nominate_film(
+                DiscordUserID=user_id3,
+                FilmName=film_name3,
+                NewFilmID=film_id1,
+                DateTime=time1,
+            )
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Cast a vote that will change the order of the nominations
+        guild2 = "guild2"
+        filmbot2 = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild2)
+        # Nominate exactly the same as we did for guild1 and check that it's
+        # fine and all added under the other guild PK
+        filmbot2.nominate_film(
+            DiscordUserID=user_id1,
+            FilmName=film_name1,
+            NewFilmID=film_id1,
+            DateTime=time1,
+        )
+
         self.assertEqual(
-            self.filmbot.cast_preference_vote(
-                DiscordUserID=dummy_user_id, FilmID=film_id2
+            grab_db(self.dynamodb_client),
+            {
+                guild1: [
+                    {
+                        "SK": f"FILM.NOMINATED.{film_id1}",
+                        "FilmName": film_name1,
+                        "DiscordUserID": user_id1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "DateNominated": time1.isoformat(),
+                    },
+                    {
+                        "SK": f"FILM.NOMINATED.{film_id2}",
+                        "FilmName": film_name2,
+                        "DiscordUserID": user_id2,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "DateNominated": time2.isoformat(),
+                    },
+                    {
+                        "SK": f"USER.{user_id1}",
+                        "NominatedFilmID": film_id1,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                    {
+                        "SK": f"USER.{user_id2}",
+                        "NominatedFilmID": film_id2,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                ],
+                guild2: [
+                    {
+                        "SK": f"FILM.NOMINATED.{film_id1}",
+                        "FilmName": film_name1,
+                        "DiscordUserID": user_id1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "DateNominated": time1.isoformat(),
+                    },
+                    {
+                        "SK": f"USER.{user_id1}",
+                        "NominatedFilmID": film_id1,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                ],
+            },
+        )
+
+    def test_workflow(self):
+        """
+        Test voting, watching, and attendance
+        """
+        guild1 = "Guild1"
+        user_id1 = "User1"
+        user_id2 = "User2"
+        user_id3 = "User3"
+        film_id1 = "Film1"
+        film_id2 = "Film2"
+        film_id3 = "Film3"
+        film_watched = "Film4"
+        d = datetime(2010, 1, 2, 3, 4, 5)
+        ages_ago = d - timedelta(days=100)
+        expected = {
+            guild1: [
+                {
+                    "SK": f"FILM.NOMINATED.{film_id1}",
+                    "FilmName": "My Film 1",
+                    "DiscordUserID": user_id1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM.NOMINATED.{film_id2}",
+                    "FilmName": "My Film 2",
+                    "DiscordUserID": user_id2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM.NOMINATED.{film_id3}",
+                    "FilmName": "My Film 3",
+                    "DiscordUserID": user_id3,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM.WATCHED.{ages_ago.isoformat()}.Super-old-film",
+                    "FilmName": "My Film 4 (Watched)",
+                    "DiscordUserID": user_id1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": ages_ago.isoformat(),
+                },
+                {
+                    "SK": f"FILM.WATCHED.{d.isoformat()}.{film_watched}",
+                    "FilmName": "My Film 5 (Watched)",
+                    "DiscordUserID": user_id1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"USER.{user_id1}",
+                    "NominatedFilmID": film_id1,
+                    "VoteID": None,
+                    "AttendanceVoteID": "dummy",
+                },
+                {
+                    "SK": f"USER.{user_id2}",
+                    "NominatedFilmID": film_id2,
+                    "VoteID": None,
+                    "AttendanceVoteID": "dummy2",
+                },
+                {
+                    "SK": f"USER.{user_id3}",
+                    "NominatedFilmID": film_id3,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+            ]
+        }
+
+        # Create indices into `expected` that we can use later on
+        FILM_1 = 0
+        FILM_2 = 1
+        FILM_3 = 2
+        USER_1 = 5
+        USER_2 = 6
+        USER_3 = 7
+
+        # Set up the database
+        set_db(self.dynamodb_client, expected)
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+        filmbot = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild1)
+
+        # Check we can't vote if we're not registered
+        with self.assertRaises(UserError):
+            filmbot.cast_preference_vote(
+                DiscordUserID="not registered", FilmID=film_id1
+            )
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check we can't vote for an already watched film
+        with self.assertRaises(
+            self.dynamodb_client.exceptions.TransactionCanceledException
+        ):
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id1, FilmID=film_watched
+            )
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check we can't vote for a non-existent film
+        with self.assertRaises(
+            self.dynamodb_client.exceptions.TransactionCanceledException
+        ):
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id1, FilmID="not existent"
+            )
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check we can vote with no previous vote
+        self.assertEqual(
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id1, FilmID=film_id2
             ),
             VotingStatus.UNCOMPLETE,
         )
 
-        expected_users[dummy_user_id]["vote-id"] = film_id2
+        expected[guild1][FILM_2]["CastVotes"] += 1
+        expected[guild1][USER_1]["VoteID"] = film_id2
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Swap the expected films and update the total votes
-        expected_nominations[0], expected_nominations[1] = (
-            expected_nominations[1],
-            expected_nominations[0],
-        )
-        expected_nominations[0]["cast-votes"] += 1
-
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
-
-        # Check voting for the same film has no effect
+        # Check we can vote for the same film as it's a shortcut path in the code
         self.assertEqual(
-            self.filmbot.cast_preference_vote(
-                DiscordUserID=dummy_user_id, FilmID=film_id2
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id1, FilmID=film_id2
             ),
             VotingStatus.UNCOMPLETE,
         )
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Have the last vote cast
+        # Check we can change our vote
         self.assertEqual(
-            self.filmbot.cast_preference_vote(DiscordUserID="123", FilmID=film_id),
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id1, FilmID=film_id3
+            ),
+            VotingStatus.UNCOMPLETE,
+        )
+        expected[guild1][FILM_2]["CastVotes"] -= 1
+        expected[guild1][FILM_3]["CastVotes"] += 1
+        expected[guild1][USER_1]["VoteID"] = film_id3
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check we can't vote for our nomination
+        with self.assertRaises(UserError):
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id1, FilmID=film_id1
+            ),
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check that we know when voting is finished
+        self.assertEqual(
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id2, FilmID=film_id1
+            ),
+            VotingStatus.UNCOMPLETE,
+        )
+        expected[guild1][FILM_1]["CastVotes"] += 1
+        expected[guild1][USER_2]["VoteID"] = film_id1
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        self.assertEqual(
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id3, FilmID=film_id1
+            ),
             VotingStatus.COMPLETE,
         )
-        expected_users["123"]["vote-id"] = film_id
-        # Swap back as they have the same score so we rank by nomination order
-        expected_nominations[0], expected_nominations[1] = (
-            expected_nominations[1],
-            expected_nominations[0],
-        )
-        expected_nominations[0]["cast-votes"] += 1
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
+        expected[guild1][FILM_1]["CastVotes"] += 1
+        expected[guild1][USER_3]["VoteID"] = film_id1
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check voting for the same film has no effect
+        # Check that we can change votes when voting is finished
         self.assertEqual(
-            self.filmbot.cast_preference_vote(DiscordUserID="123", FilmID=film_id),
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id3, FilmID=film_id2
+            ),
             VotingStatus.COMPLETE,
         )
-        self.assertEqual(self.filmbot.get_users(), expected_users)
-        self.assertEqual(self.filmbot.get_nominations(), expected_nominations)
+        expected[guild1][FILM_1]["CastVotes"] -= 1
+        expected[guild1][FILM_2]["CastVotes"] += 1
+        expected[guild1][USER_3]["VoteID"] = film_id2
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check we can vote for the same film once voting is finished
+        self.assertEqual(
+            filmbot.cast_preference_vote(
+                DiscordUserID=user_id3, FilmID=film_id2
+            ),
+            VotingStatus.COMPLETE,
+        )
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        good_time = d + timedelta(hours=24)
+        bad_time = good_time + timedelta(seconds=1)
+
+        # Check that we can't watch a film that doesn't exist
+        with self.assertRaises(UserError):
+            filmbot.start_watching_film(
+                FilmID="non existent", DateTime=good_time
+            )
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check that we can't watch a film that has already been watched
+        with self.assertRaises(UserError):
+            filmbot.start_watching_film(
+                FilmID=film_watched, DateTime=good_time
+            )
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check we can't watch another film within 24 hours
+        with self.assertRaises(UserError):
+            filmbot.start_watching_film(FilmID=film_id1, DateTime=bad_time)
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
+
+        # Check we can watch a film
+        filmbot.start_watching_film(FilmID=film_id1, DateTime=good_time)
+
+        # Update our users
+        expected[guild1][USER_1]["NominatedFilmID"] = None
+        expected[guild1][USER_1]["VoteID"] = None
+        expected[guild1][USER_1]["AttendanceVoteID"] = None
+        expected[guild1][USER_2]["VoteID"] = None
+        expected[guild1][USER_2]["AttendanceVoteID"] = None
+        expected[guild1][USER_3]["VoteID"] = None
+
+        # Move the film to the `WATCHED` section
+        watched_film = expected[guild1].pop(FILM_1)
+        watched_film["SK"] = f"FILM.WATCHED.{good_time.isoformat()}.{film_id1}"
+        expected[guild1].insert(4, watched_film)
+        self.assertEqual(grab_db(self.dynamodb_client), expected)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+target-version = ['py37']


### PR DESCRIPTION
In order to implement attendance voting we need to be able to sort
our films by the date that they were watched.  This way we can query for
the last watched film and see whether we fall within its watch range.

To do this we change the database schema to have the Discord Guild ID be
the partition key and have our film ID/user ID be the sort key.  Based
on AWS recommendations, I have combined our tables into one and can be
differentiated with the sort key.