### PR TITLE
Fix cooldown period

### DIFF
--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -585,7 +585,7 @@ class FilmBot:
 
         if response["Items"]:
             latest_watched_film = Film.fromDict(response["Items"][0])
-            if DateTime > latest_watched_film.DateWatched + timedelta(days=1):
+            if DateTime < latest_watched_film.DateWatched + timedelta(days=1):
                 raise UserError(
                     "At least 24 hours must pass before watching films"
                 )

--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -825,7 +825,7 @@ class TestFilmBot(unittest.TestCase):
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         good_time = d + timedelta(hours=24)
-        bad_time = good_time + timedelta(seconds=1)
+        bad_time = good_time - timedelta(seconds=1)
 
         # Check that we can't watch a film that doesn't exist
         with self.assertRaises(UserError):


### PR DESCRIPTION
The conditions were reversed (totally on purpose for testing...) so that
you are actually unable to watch a film **more** than 24 hours after the
previous one, instead of before.