### PR TITLE
Make errors ephemeral

### DIFF
--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -208,7 +208,10 @@ def handle_discord(event, region_name):
             # If we get a `UserError` it's something we can display to the user
             return {
                 "type": CHANNEL_MESSAGE_WITH_SOURCE,
-                "data": {"content": f"ERROR! {str(e)}"},
+                "data": {
+                    "content": str(e),
+                    "flags": EPHEMERAL_FLAG,
+                },
             }
     elif type == MESSAGE_COMPONENT:
         raise Exception(f"Unknown type ({type})!")


### PR DESCRIPTION
Make errors show up only to the user who ran the command.

Also remove the `ERROR` part of the message as it is unnecessary.