### PR TITLE
Improve error handling for /vote

### DIFF
--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -725,18 +725,14 @@ class TestFilmBot(unittest.TestCase):
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         # Check we can't vote for an already watched film
-        with self.assertRaises(
-            self.dynamodb_client.exceptions.TransactionCanceledException
-        ):
+        with self.assertRaises(UserError):
             filmbot.cast_preference_vote(
                 DiscordUserID=user_id1, FilmID=film_watched
             )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         # Check we can't vote for a non-existent film
-        with self.assertRaises(
-            self.dynamodb_client.exceptions.TransactionCanceledException
-        ):
+        with self.assertRaises(UserError):
             filmbot.cast_preference_vote(
                 DiscordUserID=user_id1, FilmID="not existent"
             )


### PR DESCRIPTION
If you ignore the autocomplete in Discord and instead type your own text
into the `/vote` command then we hit a transaction failure and don't
display any useful text to the user.  This commit will convert the
`TransactionCanceledException` to a `UserError`, which will be displayed
nicely.