### PR TITLE
Fix nomination message

### DIFF
--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -113,16 +113,16 @@ def handle_application_command(event, region_name):
 
     elif command == "watch":
         film_id = body["data"]["options"][0]["value"]
-        film_name = filmbot.start_watching_film(
+        film = filmbot.start_watching_film(
             FilmID=film_id, DateTime=now, PresentUserIDs=[user_id]
         )
         return {
             "type": CHANNEL_MESSAGE_WITH_SOURCE,
             "data": {
                 "content": (
-                    f"Started watching {film_name}!\n\n"
+                    f"Started watching {film.FilmName}!\n\n"
                     + f"Everyone other than <@{user_id}> should record their attendance using `/here`.\n\n"
-                    + f"<@{user_id}> can now nominated their next suggestion with `/nominate`"
+                    + f"<@{film.DiscordUserID}> can now nominated their next suggestion with `/nominate`"
                 )
             },
         }

--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -539,7 +539,7 @@ class FilmBot:
         """
         Attempt to record that we're watching the specified `FilmID` and
         record an attendance vote for each user in the `PresentUserIDs` array
-        and return the name of the film.  Also clear out all cast votes
+        and return the a `Film` object.  Also clear out all cast votes
         from all users and clear out the user's nomination who had previously
         nominated `FilmID`.  Throw an exception if `FilmID` isn't correct,
         less than 24 hours has passed since watching the last film, or
@@ -681,7 +681,7 @@ class FilmBot:
         ]
         self.client.transact_write_items(TransactItems=items)
 
-        return film.FilmName
+        return film
 
     def record_attendance_vote(self, *, DiscordUserID, DateTime):
         """

--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -860,7 +860,16 @@ class TestFilmBot(unittest.TestCase):
                     DateTime=good_time,
                     PresentUserIDs=[user_id1, user_id2, user_id3],
                 ),
-                "My Film 1",
+                Film(
+                    FilmID=film_id1,
+                    FilmName="My Film 1",
+                    DiscordUserID=user_id1,
+                    CastVotes=1,
+                    AttendanceVotes=0,
+                    UsersAttended=set([user_id1, user_id2, user_id3]),
+                    DateNominated=d,
+                    DateWatched=good_time,
+                ),
             )
 
             # Update our users
@@ -890,7 +899,16 @@ class TestFilmBot(unittest.TestCase):
             filmbot.start_watching_film(
                 FilmID=film_id1, DateTime=good_time, PresentUserIDs=[user_id1]
             ),
-            "My Film 1",
+            Film(
+                FilmID=film_id1,
+                FilmName="My Film 1",
+                DiscordUserID=user_id1,
+                CastVotes=1,
+                AttendanceVotes=0,
+                UsersAttended=set([user_id1]),
+                DateNominated=d,
+                DateWatched=good_time,
+            ),
         )
 
         # Update our users


### PR DESCRIPTION
The message incorrect states that the person who ran `/watch` should be
the person to nominate the next film.  Instead it should get the
`DiscordUserID` for that film and use their name.

To do this we return an entire `Film` object from `start_watching_film`
and grab the nominator from that.