### PR TITLE
Add IMDb integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ fields:
 The records with sort key starting with `"FILM.*"` contains the following fields:
   * `FilmName` is a string representation of the film's name
   * `DiscordUserID` is a string matching the users's Discord ID who nominated this film
+  * `IMDbID` is `NULL` or an IMDB ID (e.g. "0113375")
+  * `DiscordUserID` is a string matching the users's Discord ID who nominated this film
   * `CastVotes` is a non-negative integer representing the number of votes cast for this film
   * `AttendanceVotes` is a non-negative integer representing the number of attendance votes for the user who nominated this film
   * `UsersAttended` is `NULL` for unwatched films or a non-empty set containing the user's Discord IDs of those who have attended (DynamoDB does not support empty string sets)

--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -15,6 +15,7 @@ USER_AttendanceVoteID = "AttendanceVoteID"
 FILM_PK = "PK"
 FILM_SK = "SK"
 FILM_FilmName = "FilmName"
+FILM_IMDbID = "IMDbID"
 FILM_DiscordUserID = "DiscordUserID"
 FILM_CastVotes = "CastVotes"
 FILM_AttendanceVotes = "AttendanceVotes"
@@ -73,6 +74,7 @@ class Film:
         *,
         FilmID,
         FilmName,
+        IMDbID,
         DiscordUserID,
         CastVotes,
         AttendanceVotes,
@@ -82,6 +84,7 @@ class Film:
     ):
         self.FilmID = FilmID
         self.FilmName = FilmName
+        self.IMDbID = IMDbID
         self.DiscordUserID = DiscordUserID
         self.CastVotes = CastVotes
         self.AttendanceVotes = AttendanceVotes
@@ -101,6 +104,7 @@ class Film:
         return (
             self.FilmID == other.FilmID
             and self.FilmName == other.FilmName
+            and self.IMDbID == other.IMDbID
             and self.DiscordUserID == other.DiscordUserID
             and self.CastVotes == other.CastVotes
             and self.AttendanceVotes == other.AttendanceVotes
@@ -114,6 +118,7 @@ class Film:
             f"SK={self.SK}\n"
             f"FilmID={self.FilmID}\n"
             f"FilmName={self.FilmName}\n"
+            f"IMDbID={self.IMDbID}\n"
             f"DiscordUserID={self.DiscordUserID}\n"
             f"CastVotes={self.CastVotes}\n"
             f"AttendanceVotes={self.AttendanceVotes}\n"
@@ -127,6 +132,7 @@ class Film:
             "PK": {"S": GuildID},
             "SK": {"S": self.SK},
             "FilmName": {"S": self.FilmName},
+            "IMDbID": keyed(self.IMDbID),
             "DiscordUserID": {"S": self.DiscordUserID},
             "CastVotes": {"N": str(self.CastVotes)},
             "AttendanceVotes": {"N": str(self.AttendanceVotes)},
@@ -146,6 +152,7 @@ class Film:
         return Film(
             FilmID=sk_parts[-1],
             FilmName=dict[FILM_FilmName]["S"],
+            IMDbID=unkeyed(dict[FILM_IMDbID]),
             DiscordUserID=dict[FILM_DiscordUserID]["S"],
             CastVotes=int(dict[FILM_CastVotes]["N"]),
             AttendanceVotes=int(dict[FILM_AttendanceVotes]["N"]),
@@ -366,17 +373,26 @@ class FilmBot:
 
         return sorted(films, key=lambda n: n.DateNominated)
 
-    def nominate_film(self, *, DiscordUserID, FilmName, NewFilmID, DateTime):
+    def nominate_film(
+        self,
+        *,
+        DiscordUserID,
+        FilmName,
+        NewFilmID,
+        IMDbID,
+        DateTime,
+    ):
         """
-        Attempt to nominate the specified `FilmName` as the film choice for the
-        specified `DiscordUserID`.  If `DiscordUserID` is not a registered user
-        then register them.  If `DiscordUserID` already has a nomination then
-        throw an exception.
+        Attempt to nominate the specified `FilmName` as the film choice, with
+        the specified `IMDbID` for the specified `DiscordUserID`.  If
+        `DiscordUserID` is not a registered user then register them.  If
+        `DiscordUserID` already has a nomination then throw an exception.
         """
 
         new_film = Film(
             FilmID=NewFilmID,
             FilmName=FilmName,
+            IMDbID=IMDbID,
             DiscordUserID=DiscordUserID,
             CastVotes=0,
             AttendanceVotes=0,

--- a/discord_handler/requirements.txt
+++ b/discord_handler/requirements.txt
@@ -1,2 +1,3 @@
 boto3
 pynacl
+IMDbPY

--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -231,6 +231,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": "FILM#NOMINATED#film1",
                 "FilmName": "FilmName1",
+                "IMDbID": None,
                 "DiscordUserID": "UserA",
                 "CastVotes": 0,
                 "AttendanceVotes": 7,
@@ -240,6 +241,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": "FILM#NOMINATED#film2",
                 "FilmName": "FilmName2",
+                "IMDbID": "0234567",
                 "DiscordUserID": "UserB",
                 "CastVotes": 3,
                 "AttendanceVotes": 3,
@@ -249,6 +251,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": "FILM#NOMINATED#film3",
                 "FilmName": "FilmName3",
+                "IMDbID": "0345678",
                 "DiscordUserID": "UserC",
                 "CastVotes": 2,
                 "AttendanceVotes": 3,
@@ -258,6 +261,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": "FILM#NOMINATED#film4",
                 "FilmName": "FilmName4",
+                "IMDbID": "03456789",
                 "DiscordUserID": "UserD",
                 "CastVotes": 2,
                 "AttendanceVotes": 4,
@@ -267,6 +271,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": "FILM#NOMINATED#film5",
                 "FilmName": "FilmName5",
+                "IMDbID": "04567890",
                 "DiscordUserID": "UserE",
                 "CastVotes": 2,
                 "AttendanceVotes": 4,
@@ -276,6 +281,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": f"FILM#WATCHED#{d.isoformat()}#film6",
                 "FilmName": "FilmName6",
+                "IMDbID": "05678901",
                 "DiscordUserID": "UserF",
                 "CastVotes": 10,
                 "AttendanceVotes": 9,
@@ -288,6 +294,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film1",
                 FilmName="FilmName1",
+                IMDbID=None,
                 DiscordUserID="UserA",
                 CastVotes=0,
                 AttendanceVotes=7,
@@ -298,6 +305,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film2",
                 FilmName="FilmName2",
+                IMDbID="0234567",
                 DiscordUserID="UserB",
                 CastVotes=3,
                 AttendanceVotes=3,
@@ -308,6 +316,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film4",
                 FilmName="FilmName4",
+                IMDbID="03456789",
                 DiscordUserID="UserD",
                 CastVotes=2,
                 AttendanceVotes=4,
@@ -318,6 +327,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film5",
                 FilmName="FilmName5",
+                IMDbID="04567890",
                 DiscordUserID="UserE",
                 CastVotes=2,
                 AttendanceVotes=4,
@@ -328,6 +338,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film3",
                 FilmName="FilmName3",
+                IMDbID="0345678",
                 DiscordUserID="UserC",
                 CastVotes=2,
                 AttendanceVotes=3,
@@ -361,6 +372,7 @@ class TestFilmBot(unittest.TestCase):
                 "SK": "FILM#NOMINATED#film1",
                 "FilmName": "FilmName1",
                 "DiscordUserID": "UserA",
+                "IMDbID": "0123",
                 "CastVotes": 0,
                 "AttendanceVotes": 7,
                 "UsersAttended": None,
@@ -369,6 +381,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": "FILM#NOMINATED#film2",
                 "FilmName": "FilmName2",
+                "IMDbID": "0124",
                 "DiscordUserID": "UserB",
                 "CastVotes": 3,
                 "AttendanceVotes": 3,
@@ -378,6 +391,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": f"FILM#WATCHED#{(d + timedelta(seconds=1)).isoformat()}#film3",
                 "FilmName": "FilmName3",
+                "IMDbID": "0125",
                 "DiscordUserID": "UserC",
                 "CastVotes": 2,
                 "AttendanceVotes": 4,
@@ -387,6 +401,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "SK": f"FILM#WATCHED#{d.isoformat()}#film4",
                 "FilmName": "FilmName4",
+                "IMDbID": "0126",
                 "DiscordUserID": "UserD",
                 "CastVotes": 10,
                 "AttendanceVotes": 9,
@@ -399,6 +414,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film1",
                 FilmName="FilmName1",
+                IMDbID="0123",
                 DiscordUserID="UserA",
                 CastVotes=0,
                 AttendanceVotes=7,
@@ -409,6 +425,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film3",
                 FilmName="FilmName3",
+                IMDbID="0125",
                 DiscordUserID="UserC",
                 CastVotes=2,
                 AttendanceVotes=4,
@@ -419,6 +436,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film2",
                 FilmName="FilmName2",
+                IMDbID="0124",
                 DiscordUserID="UserB",
                 CastVotes=3,
                 AttendanceVotes=3,
@@ -429,6 +447,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID="film4",
                 FilmName="FilmName4",
+                IMDbID="0126",
                 DiscordUserID="UserD",
                 CastVotes=10,
                 AttendanceVotes=9,
@@ -451,6 +470,7 @@ class TestFilmBot(unittest.TestCase):
 
     def test_nominate_film(self):
         user_id1 = "user1"
+        imdb1 = "012341"
         film_id1 = str(uuid1())
         film_name1 = "My Film"
         time1 = datetime(2001, 1, 2, 3, 4, 5, 123)
@@ -461,6 +481,7 @@ class TestFilmBot(unittest.TestCase):
         filmbot.nominate_film(
             DiscordUserID=user_id1,
             FilmName=film_name1,
+            IMDbID=imdb1,
             NewFilmID=film_id1,
             DateTime=time1,
         )
@@ -473,6 +494,7 @@ class TestFilmBot(unittest.TestCase):
                         "SK": f"FILM#NOMINATED#{film_id1}",
                         "FilmName": film_name1,
                         "DiscordUserID": user_id1,
+                        "IMDbID": imdb1,
                         "CastVotes": 0,
                         "AttendanceVotes": 0,
                         "UsersAttended": None,
@@ -490,10 +512,12 @@ class TestFilmBot(unittest.TestCase):
 
         # Check nominating fails when you already have a nomination
         film_name2 = "My Film 2: The Sequel"
+        imdb2 = "012342"
         with self.assertRaises(UserError):
             filmbot.nominate_film(
                 DiscordUserID=user_id1,
                 FilmName=film_name2,
+                IMDbID=imdb2,
                 NewFilmID=film_id1,
                 DateTime=time1,
             )
@@ -504,6 +528,7 @@ class TestFilmBot(unittest.TestCase):
         filmbot.nominate_film(
             DiscordUserID=user_id2,
             FilmName=film_name2,
+            IMDbID=imdb2,
             NewFilmID=film_id2,
             DateTime=time2,
         )
@@ -514,6 +539,7 @@ class TestFilmBot(unittest.TestCase):
                     "SK": f"FILM#NOMINATED#{film_id1}",
                     "FilmName": film_name1,
                     "DiscordUserID": user_id1,
+                    "IMDbID": imdb1,
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
                     "UsersAttended": None,
@@ -522,6 +548,7 @@ class TestFilmBot(unittest.TestCase):
                 {
                     "SK": f"FILM#NOMINATED#{film_id2}",
                     "FilmName": film_name2,
+                    "IMDbID": imdb2,
                     "DiscordUserID": user_id2,
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
@@ -547,10 +574,12 @@ class TestFilmBot(unittest.TestCase):
         # Check we can't reuse film IDs
         user_id3 = "user3"
         film_name3 = "My Film 3: The Return of The Unit Test"
+        imdb3 = "012343"
         with self.assertRaises(UserError):
             filmbot.nominate_film(
                 DiscordUserID=user_id3,
                 FilmName=film_name3,
+                IMDbID=imdb3,
                 NewFilmID=film_id1,
                 DateTime=time1,
             )
@@ -563,6 +592,7 @@ class TestFilmBot(unittest.TestCase):
         filmbot2.nominate_film(
             DiscordUserID=user_id1,
             FilmName=film_name1,
+            IMDbID=imdb1,
             NewFilmID=film_id1,
             DateTime=time1,
         )
@@ -574,6 +604,7 @@ class TestFilmBot(unittest.TestCase):
                     {
                         "SK": f"FILM#NOMINATED#{film_id1}",
                         "FilmName": film_name1,
+                        "IMDbID": imdb1,
                         "DiscordUserID": user_id1,
                         "CastVotes": 0,
                         "AttendanceVotes": 0,
@@ -583,6 +614,7 @@ class TestFilmBot(unittest.TestCase):
                     {
                         "SK": f"FILM#NOMINATED#{film_id2}",
                         "FilmName": film_name2,
+                        "IMDbID": imdb2,
                         "DiscordUserID": user_id2,
                         "CastVotes": 0,
                         "AttendanceVotes": 0,
@@ -606,6 +638,7 @@ class TestFilmBot(unittest.TestCase):
                     {
                         "SK": f"FILM#NOMINATED#{film_id1}",
                         "FilmName": film_name1,
+                        "IMDbID": imdb1,
                         "DiscordUserID": user_id1,
                         "CastVotes": 0,
                         "AttendanceVotes": 0,
@@ -633,6 +666,11 @@ class TestFilmBot(unittest.TestCase):
         film_id1 = "Film1"
         film_id2 = "Film2"
         film_id3 = "Film3"
+        imdb1 = "0121"
+        imdb2 = "0122"
+        imdb3 = "0123"
+        imdb4 = "0124"
+        imdb5 = "0125"
         film_watched = "Film4"
         d = datetime(2010, 1, 2, 3, 4, 5, 678)
         ages_ago = d - timedelta(days=100)
@@ -641,6 +679,7 @@ class TestFilmBot(unittest.TestCase):
                 {
                     "SK": f"FILM#NOMINATED#{film_id1}",
                     "FilmName": "My Film 1",
+                    "IMDbID": imdb1,
                     "DiscordUserID": user_id1,
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
@@ -650,6 +689,7 @@ class TestFilmBot(unittest.TestCase):
                 {
                     "SK": f"FILM#NOMINATED#{film_id2}",
                     "FilmName": "My Film 2",
+                    "IMDbID": imdb2,
                     "DiscordUserID": user_id2,
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
@@ -659,6 +699,7 @@ class TestFilmBot(unittest.TestCase):
                 {
                     "SK": f"FILM#NOMINATED#{film_id3}",
                     "FilmName": "My Film 3",
+                    "IMDbID": imdb3,
                     "DiscordUserID": "dummy",
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
@@ -668,6 +709,7 @@ class TestFilmBot(unittest.TestCase):
                 {
                     "SK": f"FILM#WATCHED#{ages_ago.isoformat()}#Super-old-film",
                     "FilmName": "My Film 4 (Watched)",
+                    "IMDbID": imdb4,
                     "DiscordUserID": user_id1,
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
@@ -677,6 +719,7 @@ class TestFilmBot(unittest.TestCase):
                 {
                     "SK": f"FILM#WATCHED#{d.isoformat()}#{film_watched}",
                     "FilmName": "My Film 5 (Watched)",
+                    "IMDbID": imdb5,
                     "DiscordUserID": user_id1,
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
@@ -859,6 +902,7 @@ class TestFilmBot(unittest.TestCase):
                 Film(
                     FilmID=film_id1,
                     FilmName="My Film 1",
+                    IMDbID=imdb1,
                     DiscordUserID=user_id1,
                     CastVotes=1,
                     AttendanceVotes=0,
@@ -898,6 +942,7 @@ class TestFilmBot(unittest.TestCase):
             Film(
                 FilmID=film_id1,
                 FilmName="My Film 1",
+                IMDbID=imdb1,
                 DiscordUserID=user_id1,
                 CastVotes=1,
                 AttendanceVotes=0,

--- a/register_application_commands/register_application_commands.py
+++ b/register_application_commands/register_application_commands.py
@@ -49,6 +49,7 @@ commands = [
                 "description": "The name of the film you would like to nominate",
                 "type": 3,
                 "required": True,
+                "autocomplete": True,
             }
         ],
     },


### PR DESCRIPTION
Add IMDb-powered autocomplete for the `/nominate` application command
using `PyIMDb`.  If the user doesn't use the autocomplete, then they
will add a film without a corresponding IMDb movie ID.

When handling the `/nominate` command, we can't call `ia.get_movie` and
get the title without exceeding the 3s Discord response window.  To
avoid changing the architecture too much, we encode both the film namd
and IMDb movie ID in the autocomplete value and trust that this is
accurrate.  It is possible for a user to manually type a film in the
format `IMDB:[movie id]:[film name]` with mismatching movie ID and film
name.  However, we are working with (somewhat) trusted users so this
isn't too much of a risk.

Store the IMDb movie ID in the database and display a clickable link
when listing out the current nominations.