### PR TITLE
Add /history application command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fields:
   * `VoteID` is a string matching a `"FILM#NOMINATED#*"` sort key that represents this user's voted film, or `NULL` if this user has not voted yet in this round
   * `AttendanceVoteID` is a string matching a `"FILM#WATCHED#*.*"` sort key that represents this user's attendance vote for the last watched film, or `NULL` if this user did not watch the latest film
 
-### "FILM.*" Record Format
+### "FILM#*" Record Format
 
 The records with sort key starting with `"FILM.*"` contains the following fields:
   * `FilmName` is a string representation of the film's name

--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -352,6 +352,30 @@ class FilmBot:
             ],
         )
 
+    def get_watched_films(self):
+        """
+        Return an array of watched films ordered by most recently watched.
+        """
+        return list(
+            map(
+                Film.fromDict,
+                self.__query(
+                    {
+                        "TableName": TABLE_NAME,
+                        "ExpressionAttributeValues": {
+                            ":GuildID": {"S": self.guildID},
+                            ":FilmPrefix": {"S": "FILM#WATCHED#"},
+                        },
+                        "KeyConditionExpression": (
+                            f"{FILM_PK} = :GuildID AND "
+                            f"begins_with({FILM_SK}, :FilmPrefix)"
+                        ),
+                        "ScanIndexForward": False,
+                    }
+                ),
+            )
+        )
+
     def get_all_films(self):
         """
         Return an array watched and unwatched films in the order that they were

--- a/register_application_commands/register_application_commands.py
+++ b/register_application_commands/register_application_commands.py
@@ -83,6 +83,11 @@ commands = [
         "type": 1,
         "description": "Display the users with outstanding tasks",
     },
+    {
+        "name": "history",
+        "type": 1,
+        "description": "Display the films that have previously been watched",
+    },
 ]
 
 headers = {"Authorization": f'Bot {config["bot_token"]["value"]}'}


### PR DESCRIPTION
Add a way to list all of the films that have been watched in reverse
chronological order.

We are limited to 2000 characters in a Discord message so at some point
we won't show all of the films with `/history`.  In that case we should
most likely add a "View More" button at the end of the message that
displays the next chunk of films.