### PR TITLE
Format datetime for /history

### DIFF
--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -87,7 +87,7 @@ def display_watched(f: Film):
         if f.IMDbID is not None
         else ""
     )
-    return f"  • {f.DateWatched.strftime('%Y-%m-%d')} {f.FilmName}{imdb} - <@{f.DiscordUserID}>"
+    return f"  • <t:{int(f.DateWatched.timestamp())}:d> {f.FilmName}{imdb} - <@{f.DiscordUserID}>"
 
 
 def naughty_message(filmbot):


### PR DESCRIPTION
Use Discord's timestamp formatting functionality to format short
datetimes (`:d`) the way that the user wants rather than stick to
ISO8601.

Documentation: https://discord.com/developers/docs/reference#message-formatting-formats