### PR TITLE
Fix markdown lists

### DIFF
--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -73,11 +73,11 @@ def display_nomination(nomination):
         if n.IMDbID is not None
         else ""
     )
-    return f"  {position}. <@{n.DiscordUserID}> {n.FilmName} ({vote_count} vote{s}){imdb}"
+    return f"{position}. <@{n.DiscordUserID}> {n.FilmName} ({vote_count} vote{s}){imdb}"
 
 
 def display_user(user):
-    return f"  - <@{user.DiscordUserID}>"
+    return f"- <@{user.DiscordUserID}>"
 
 
 def display_watched(f: Film):
@@ -87,7 +87,7 @@ def display_watched(f: Film):
         if f.IMDbID is not None
         else ""
     )
-    return f"  • <t:{int(f.DateWatched.timestamp())}:d> {f.FilmName}{imdb} - <@{f.DiscordUserID}>"
+    return f"- <t:{int(f.DateWatched.timestamp())}:d> {f.FilmName}{imdb} - <@{f.DiscordUserID}>"
 
 
 def naughty_message(filmbot):


### PR DESCRIPTION
Discord markdown lists cannot start with indentation otherwise it is understood as nested lists.

> You can create a bulleted list using either (-) or (*) in the
> beginning of each line

https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline