### PR TITLE
Change user sort key and improve `/peek`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@
   3. `pip install -r requirements.txt`
   4. `python test_filmbot.py`
 
+## Formatting
+
+  1. `black *.py`
+
 ## Creating AWS Layer
 
 On a Linux x64 machine (e.g. an EC2 Amazon Linux instance)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ called "PK" and a sort key called "SK".
 The partition key will be Discord Guild ID.
 
 The sort key will take one of the following forms:
-  1. `"USER#" + DiscordUserID`
+  1. `"DISCORDUSER#" + DiscordUserID`
   2. `"FILM#NOMINATED#" + FilmID`
   3. `"FILM#WATCHED#" + DateTimeStarted + "." + FilmID`
 
@@ -27,17 +27,19 @@ Where:
      film was started being watched
 
 For example:
-  1. `"USER#16393729388392"`
+  1. `"DISCORDUSER#16393729388392"`
   2. `"FILM#NOMINATED#76988c8a-a15d-48a9-8805-5c7f1723e298"`
   3. `"FILM#WATCHED#2022-01-19T21:35:58Z.76988c8a-a15d-48a9-8805-5c7f1723e298"`
 
-### "USER#*" Record Format
+### "DISCORDUSER#*" Record Format
 
-The records with sort key starting with `"USER#*"` contains the following
+The records with sort key starting with `"DISCORDUSER#*"` contains the following
 fields:
   * `NominatedFilmID` is a string matching a `"FILM#NOMINATED#*"` sort key that represents this users nominated film, or `NULL` if this user has no currently nominated film
   * `VoteID` is a string matching a `"FILM#NOMINATED#*"` sort key that represents this user's voted film, or `NULL` if this user has not voted yet in this round
   * `AttendanceVoteID` is a string matching a `"FILM#WATCHED#*.*"` sort key that represents this user's attendance vote for the last watched film, or `NULL` if this user did not watch the latest film
+
+***WARNING*** There cannot be any entries that appear alphabetically between `DISCORDUSER#` and `FILM#NOMINATED`.  This is because we would like to get all users and all nominated films in one go in order to display what the current voting situation is.
 
 ### "FILM#*" Record Format
 


### PR DESCRIPTION
Improve `/peek` by displaying users who have not nominated any films yet.  This is part of the way to moving all the information in `/naughty` to `/peek`.

In order to support this, we need to be able to query the film name and vote count by user.  We probably should be duplicating this information into the user record, which is the noSQL way.  However, if we change the sort key for users from `USER#` to `DISCORDUSER#`, then we are able to grab all users and `FILM#NOMINATION#` entries with one query because they would be next to each other alphabetically.

In an unrelated change - that really should be a separate change - we fix some of the `datetime` imports that no longer work on Python 3.9.