### PR TITLE
Change GH Actions Python version to 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8' # Same as used in AWS Lambda
+        python-version: '3.9' # Same as used in AWS Lambda
     - name: Install dependencies
       working-directory: ./discord_handler
       run: |


### PR DESCRIPTION
The AWS lambda version we use has changed from 3.8 -> 3.9.