### PR TITLE
Fix datetime comparison

### DIFF
--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -191,7 +191,7 @@ def handle_application_command(event, client):
       * /watch [FilmID]
       * /here
     """
-    now = dt.datetime.now(dt.timezone.utc)
+    now = dt.datetime.now()
     body = event["body-json"]
     command = body["data"]["name"]
     guild_id = body["guild_id"]
@@ -426,7 +426,7 @@ def handle_autocomplete(event, client):
 
 def handle_message_component(event, client):
     body = event["body-json"]
-    now = dt.datetime.now(dt.timezone.utc)
+    now = dt.datetime.now()
     component_type = body["data"]["component_type"]
     if component_type != DiscordMessageComponent.BUTTON:
         raise Exception(f"Unknown message component ({component_type})!")


### PR DESCRIPTION
In `/watch` we compare timezone-aware and non-timezone-aware `datetime` values, which results in a runtime exception.

Instead of adding timezones to everything it is far simpler to remove the timezone in the 2 places we use it.