### PR TITLE
Add `/retire`

### DIFF
--- a/discord_handler/dev_requirements.txt
+++ b/discord_handler/dev_requirements.txt
@@ -1,2 +1,3 @@
 black
+boto3
 moto ~= 3.1

--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -54,6 +54,7 @@ class MessageComponentID:
     ATTENDANCE = "register_attendance"
     SHAME = "shame"
     MORE_HISTORY = "more_history#"
+    CONFIRM_RETIRE = "confirm_retire#"
 
 
 def films_to_choices(films):
@@ -121,7 +122,7 @@ def display_watched(f: Film, user):
 
 
 def get_history(filmbot: FilmBot, user, nextKey=None, MessagePrefix=""):
-    (films, nextKey) = filmbot.get_watched_films_after(
+    films, nextKey = filmbot.get_watched_films_after(
         Limit=HISTORY_LIMIT, ExclusiveStartKey=nextKey
     )
     if films:
@@ -185,12 +186,13 @@ def register_attendance(*, FilmBot, DiscordUserID, DateTime):
 
 def handle_application_command(event, client):
     """
-    Handle the 6 application commands that we support:
+    Handle the application commands that we support:
       * /nominate [FilmName]
       * /vote [FilmID]
       * /peek
       * /watch [FilmID]
       * /here
+      * /retire [user]
     """
     now = dt.datetime.now()
     body = event["body-json"]
@@ -348,6 +350,44 @@ def handle_application_command(event, client):
             user_id,
             MessagePrefix="Here are the films that have been watched:\n",
         )
+    elif command == "retire":
+        target_user_id = body["data"]["options"][0]["value"]
+        reason = filmbot.can_retire(DiscordUserID=target_user_id)
+        if reason is not None:
+            return {
+                "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
+                "data": {
+                    "content": reason,
+                    "flags": DiscordFlag.EPHEMERAL_FLAG,
+                },
+            }
+        return {
+            "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
+            "data": {
+                "content": (
+                    f"Please confirm whether you would like to retire <@{target_user_id}>.\n"
+                    f"The following checks have passed:\n"
+                    f"- <@{target_user_id}> has not cast a preference vote\n"
+                    f"- No other user is currently voting for their nominated film\n"
+                    f"- <@{target_user_id}> has not attended any of the last 5 films"
+                ),
+                "flags": DiscordFlag.EPHEMERAL_FLAG,
+                "components": [
+                    {
+                        "type": DiscordMessageComponent.ACTION_ROW,
+                        "components": [
+                            {
+                                "type": DiscordMessageComponent.BUTTON,
+                                "label": "Confirm",
+                                "style": DiscordStyle.DANGER,
+                                "custom_id": MessageComponentID.CONFIRM_RETIRE
+                                + target_user_id,
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
     else:
         raise Exception(f"Unknown application command (/{command})")
 
@@ -474,6 +514,18 @@ def handle_message_component(event, client):
             body["member"]["user"]["id"],
             nextKey=custom_id.removeprefix(MessageComponentID.MORE_HISTORY),
         )
+    elif custom_id.startswith(MessageComponentID.CONFIRM_RETIRE):
+        filmbot = FilmBot(DynamoDBClient=client, GuildID=body["guild_id"])
+        target_user_id = custom_id.removeprefix(
+            MessageComponentID.CONFIRM_RETIRE
+        )
+        filmbot.retire_user(DiscordUserID=target_user_id)
+        return {
+            "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
+            "data": {
+                "content": f"<@{target_user_id}> has been retired.",
+            },
+        }
     else:
         raise Exception(
             f"Unknown 'custom_id' for button component ({custom_id})!"

--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -828,6 +828,164 @@ class FilmBot:
 
         return film
 
+    def _check_retire(self, *, DiscordUserID):
+        """
+        Returns a ``(reason, nominated_film)`` tuple where:
+          - ``reason`` is ``None`` when the user is eligible, or a human-readable
+            string (suitable for passing to `UserError`) explaining why they are not.
+          - ``nominated_film`` is the ``Film`` record for their current nomination, or ``None`` if they
+            have no nomination or the nominated film record no longer exists.
+        """
+        response = self.client.get_item(
+            TableName=TABLE_NAME,
+            Key={
+                USER_PK: {"S": self.guildID},
+                USER_SK: {"S": f"DISCORDUSER#{DiscordUserID}"},
+            },
+        )
+        if "Item" not in response:
+            raise UserError(f"<@{DiscordUserID}> is not a registered user")
+
+        user = User.fromDict(response["Item"])
+
+        if user.VoteID is not None:
+            return (
+                f"<@{DiscordUserID}> cannot be retired as they have an outstanding vote",
+                None,
+            )
+
+        nominated_film = None
+        if user.NominatedFilmID is not None:
+            film_response = self.client.get_item(
+                TableName=TABLE_NAME,
+                Key={
+                    FILM_PK: {"S": self.guildID},
+                    FILM_SK: {"S": f"FILM#NOMINATED#{user.NominatedFilmID}"},
+                },
+            )
+            nominated_film = (
+                Film.fromDict(film_response["Item"])
+                if "Item" in film_response
+                else None
+            )
+            if nominated_film is not None:
+                all_users = self.get_users()
+                for other_user_id, other_user in all_users.items():
+                    if (
+                        other_user_id != DiscordUserID
+                        and other_user.VoteID == user.NominatedFilmID
+                    ):
+                        return (
+                            f"<@{DiscordUserID}> cannot be retired as other users have voted for their film",
+                            None,
+                        )
+
+        # Watched film records are immutable once written, so this read is
+        # not subject to a race condition.
+        response = self.client.query(
+            TableName=TABLE_NAME,
+            ExpressionAttributeValues={
+                ":GuildID": {"S": self.guildID},
+                ":WatchedPrefix": {"S": "FILM#WATCHED#"},
+            },
+            KeyConditionExpression=(
+                f"{FILM_PK} = :GuildID AND "
+                f"begins_with({FILM_SK}, :WatchedPrefix)"
+            ),
+            ScanIndexForward=False,
+            Limit=5,
+        )
+        for item in response["Items"]:
+            film = Film.fromDict(item)
+            if (
+                film.UsersAttended is not None
+                and DiscordUserID in film.UsersAttended
+            ):
+                return (
+                    f"<@{DiscordUserID}> cannot be retired as they attended one of the last 5 films",
+                    None,
+                )
+
+        return (None, nominated_film)
+
+    def can_retire(self, *, DiscordUserID):
+        """
+        Return ``None`` if the specified `DiscordUserID` is eligible to be
+        retired, or a human-readable reason string if they are not.  All of
+        the following must hold for eligibility:
+          - They have not attended any of the last 5 watched films.
+          - They have not cast a preference vote.
+          - If they have a nomination, no other user has voted for it.
+        """
+        reason, _ = self._check_retire(DiscordUserID=DiscordUserID)
+        return reason
+
+    def retire_user(self, *, DiscordUserID):
+        """
+        Attempt to retire the specified `DiscordUserID` by removing their
+        user record and, if they have a nomination, their
+        corresponding nomination record.  Throw an exception if the user is not
+        registered or any of the following hold:
+          - They attended any of the last 5 watched films.
+          - They have cast a preference vote.
+          - Another user currently has a vote for their nomination.
+        """
+        reason, nominated_film = self._check_retire(
+            DiscordUserID=DiscordUserID
+        )
+        if reason is not None:
+            raise UserError(reason)
+
+        items = [
+            {
+                "Delete": {
+                    "TableName": TABLE_NAME,
+                    "Key": {
+                        USER_PK: {"S": self.guildID},
+                        USER_SK: {"S": f"DISCORDUSER#{DiscordUserID}"},
+                    },
+                    # Guard against the user casting a vote between our read
+                    # and this commit.
+                    "ConditionExpression": f"{USER_VoteID} = :Null",
+                    "ExpressionAttributeValues": {
+                        ":Null": {"NULL": True},
+                    },
+                }
+            }
+        ]
+
+        if nominated_film is not None:
+            items.append(
+                {
+                    "Delete": {
+                        "TableName": TABLE_NAME,
+                        "Key": {
+                            FILM_PK: {"S": self.guildID},
+                            FILM_SK: {
+                                "S": f"FILM#NOMINATED#{nominated_film.FilmID}"
+                            },
+                        },
+                        # Guard against any user voting for this film between
+                        # our read and this commit.  Since we have already checked no one
+                        # voted for this film, the only thing that can change this value
+                        # is someone voting for it.
+                        "ConditionExpression": f"{FILM_CastVotes} = :ReadCastVotes",
+                        "ExpressionAttributeValues": {
+                            ":ReadCastVotes": {
+                                "N": str(nominated_film.CastVotes)
+                            },
+                        },
+                    }
+                }
+            )
+
+        try:
+            self.client.transact_write_items(TransactItems=items)
+        except self.client.exceptions.TransactionCanceledException:
+            raise UserError(
+                f"Unable to retire <@{DiscordUserID}>. Please try again."
+            )
+
     def record_attendance_vote(self, *, DiscordUserID, DateTime):
         """
         Attempt to record that the `DiscordUserID` is present and watching

--- a/discord_handler/requirements.txt
+++ b/discord_handler/requirements.txt
@@ -1,3 +1,2 @@
-boto3
 pynacl
 IMDbPY

--- a/discord_handler/test_discord_handler.py
+++ b/discord_handler/test_discord_handler.py
@@ -637,6 +637,220 @@ class TestDiscordHandler(unittest.TestCase):
             },
         )
 
+    def test_retire_user(self):
+        from datetime import datetime, timedelta
+        from filmbot import key_map
+
+        guild_id = "retire-guild"
+        user_id = "user-to-retire"
+        other_user_id = "other-user"
+        film_id = "film-abc"
+
+        d = datetime(2024, 6, 1, 12, 0, 0)
+
+        original_db = {
+            guild_id: [
+                {
+                    "SK": f"DISCORDUSER#{user_id}",
+                    "NominatedFilmID": film_id,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"DISCORDUSER#{other_user_id}",
+                    "NominatedFilmID": None,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"FILM#NOMINATED#{film_id}",
+                    "FilmName": "Film To Retire",
+                    "IMDbID": None,
+                    "DiscordUserID": user_id,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": None,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM#WATCHED#{(d - timedelta(days=5)).isoformat()}#old-film",
+                    "FilmName": "Old Film",
+                    "IMDbID": None,
+                    "DiscordUserID": other_user_id,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": {other_user_id},
+                    "DateNominated": (d - timedelta(days=6)).isoformat(),
+                },
+            ]
+        }
+        set_db(self.dynamodb_client, original_db)
+
+        # /retire when the user attended a recent film should return an informative ephemeral message
+        set_db(
+            self.dynamodb_client,
+            {
+                guild_id: [
+                    {
+                        "SK": f"DISCORDUSER#{user_id}",
+                        "NominatedFilmID": None,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                    {
+                        "SK": f"DISCORDUSER#{other_user_id}",
+                        "NominatedFilmID": None,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                    {
+                        "SK": f"FILM#WATCHED#{(d - timedelta(days=1)).isoformat()}#recent-film",
+                        "FilmName": "Recent Film",
+                        "IMDbID": None,
+                        "DiscordUserID": other_user_id,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": {user_id},
+                        "DateNominated": (d - timedelta(days=2)).isoformat(),
+                    },
+                ]
+            },
+        )
+        result = handle_discord(
+            {
+                "body-json": {
+                    "type": DiscordRequest.APPLICATION_COMMAND,
+                    "data": {
+                        "name": "retire",
+                        "options": [{"value": user_id}],
+                    },
+                    "guild_id": guild_id,
+                    "member": {"user": {"id": other_user_id}},
+                }
+            },
+            self.dynamodb_client,
+        )
+        self.assertEqual(
+            result,
+            {
+                "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
+                "data": {
+                    "content": f"<@{user_id}> cannot be retired as they attended one of the last 5 films",
+                    "flags": DiscordFlag.EPHEMERAL_FLAG,
+                },
+            },
+        )
+
+        # Reset to the original eligible DB state
+        set_db(self.dynamodb_client, original_db)
+
+        # /retire prompts for confirmation
+        result = handle_discord(
+            {
+                "body-json": {
+                    "type": DiscordRequest.APPLICATION_COMMAND,
+                    "data": {
+                        "name": "retire",
+                        "options": [{"value": user_id}],
+                    },
+                    "guild_id": guild_id,
+                    "member": {"user": {"id": other_user_id}},
+                }
+            },
+            self.dynamodb_client,
+        )
+        self.assertEqual(
+            result,
+            {
+                "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
+                "data": {
+                    "content": (
+                        f"Please confirm whether you would like to retire <@{user_id}>.\n"
+                        f"The following checks have passed:\n"
+                        f"- <@{user_id}> has not cast a preference vote\n"
+                        f"- No other user is currently voting for their nominated film\n"
+                        f"- <@{user_id}> has not attended any of the last 5 films"
+                    ),
+                    "flags": DiscordFlag.EPHEMERAL_FLAG,
+                    "components": [
+                        {
+                            "type": DiscordMessageComponent.ACTION_ROW,
+                            "components": [
+                                {
+                                    "type": DiscordMessageComponent.BUTTON,
+                                    "label": "Confirm",
+                                    "style": DiscordStyle.DANGER,
+                                    "custom_id": MessageComponentID.CONFIRM_RETIRE
+                                    + user_id,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+
+        # User should still be in the DB
+        from filmbot import FilmBot
+
+        still_registered = FilmBot(
+            DynamoDBClient=self.dynamodb_client, GuildID=guild_id
+        ).get_users()
+        self.assertIn(user_id, still_registered)
+
+        # Pressing the Confirm button should actually retire the user
+        result = handle_discord(
+            {
+                "body-json": {
+                    "type": DiscordRequest.MESSAGE_COMPONENT,
+                    "data": {
+                        "component_type": DiscordMessageComponent.BUTTON,
+                        "custom_id": MessageComponentID.CONFIRM_RETIRE
+                        + user_id,
+                    },
+                    "guild_id": guild_id,
+                    "member": {"user": {"id": other_user_id}},
+                }
+            },
+            self.dynamodb_client,
+        )
+        self.assertEqual(
+            result,
+            {
+                "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
+                "data": {
+                    "content": f"<@{user_id}> has been retired.",
+                },
+            },
+        )
+
+        # User should now be gone
+        after_retire = FilmBot(
+            DynamoDBClient=self.dynamodb_client, GuildID=guild_id
+        ).get_users()
+        self.assertNotIn(user_id, after_retire)
+
+        # Pressing Confirm again (e.g. double-click) should give an ephemeral error
+        result = handle_discord(
+            {
+                "body-json": {
+                    "type": DiscordRequest.MESSAGE_COMPONENT,
+                    "data": {
+                        "component_type": DiscordMessageComponent.BUTTON,
+                        "custom_id": MessageComponentID.CONFIRM_RETIRE
+                        + user_id,
+                    },
+                    "guild_id": guild_id,
+                    "member": {"user": {"id": other_user_id}},
+                }
+            },
+            self.dynamodb_client,
+        )
+        self.assertEqual(
+            result["type"], DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE
+        )
+        self.assertEqual(result["data"]["flags"], DiscordFlag.EPHEMERAL_FLAG)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -1366,6 +1366,214 @@ class TestFilmBot(unittest.TestCase):
         expected[guild1][FILM_1]["UsersAttended"].add(user_id3)
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
+    def test_retire_user(self):
+        guild = "TEST-GUILD"
+        filmbot = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild)
+
+        user_id1 = "user1"
+        user_id2 = "user2"
+        user_id3 = "user3"
+        film_id1 = "film-id-1"
+        film_id2 = "film-id-2"
+        film_id3 = "film-id-3"
+
+        d = datetime(2024, 1, 1, 12, 0, 0)
+
+        # Cannot retire or check a user who doesn't exist
+        with self.assertRaises(UserError):
+            filmbot.retire_user(DiscordUserID=user_id1)
+        with self.assertRaises(UserError):
+            filmbot.can_retire(DiscordUserID=user_id1)
+
+        base_data = {
+            guild: [
+                {
+                    "SK": f"DISCORDUSER#{user_id1}",
+                    "NominatedFilmID": film_id1,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"DISCORDUSER#{user_id2}",
+                    "NominatedFilmID": film_id2,
+                    "VoteID": film_id1,  # user2 has voted for user1's film
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"DISCORDUSER#{user_id3}",
+                    "NominatedFilmID": None,
+                    "VoteID": film_id1,  # user3 has voted but has no nomination
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"FILM#NOMINATED#{film_id1}",
+                    "FilmName": "Film 1",
+                    "IMDbID": None,
+                    "DiscordUserID": user_id1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": None,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM#NOMINATED#{film_id2}",
+                    "FilmName": "Film 2",
+                    "IMDbID": None,
+                    "DiscordUserID": user_id2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": None,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM#WATCHED#{(d - timedelta(days=5)).isoformat()}#{film_id3}",
+                    "FilmName": "Watched Film",
+                    "IMDbID": None,
+                    "DiscordUserID": user_id2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": {user_id1},
+                    "DateNominated": (d - timedelta(days=6)).isoformat(),
+                },
+            ]
+        }
+        set_db(self.dynamodb_client, base_data)
+
+        # Cannot retire user1: they attended a recent film and others voted for their film
+        self.assertIsNotNone(filmbot.can_retire(DiscordUserID=user_id1))
+        with self.assertRaises(UserError):
+            filmbot.retire_user(DiscordUserID=user_id1)
+
+        # Cannot retire user2: they have an outstanding vote
+        self.assertIsNotNone(filmbot.can_retire(DiscordUserID=user_id2))
+        with self.assertRaises(UserError):
+            filmbot.retire_user(DiscordUserID=user_id2)
+
+        # Cannot retire user3: they have an outstanding vote
+        self.assertIsNotNone(filmbot.can_retire(DiscordUserID=user_id3))
+        with self.assertRaises(UserError):
+            filmbot.retire_user(DiscordUserID=user_id3)
+
+        # Set up an eligible scenario: user3 has no nomination, no vote, no recent attendance
+        eligible_data = {
+            guild: [
+                {
+                    "SK": f"DISCORDUSER#{user_id1}",
+                    "NominatedFilmID": film_id1,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"DISCORDUSER#{user_id2}",
+                    "NominatedFilmID": film_id2,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"DISCORDUSER#{user_id3}",
+                    "NominatedFilmID": None,
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
+                },
+                {
+                    "SK": f"FILM#NOMINATED#{film_id1}",
+                    "FilmName": "Film 1",
+                    "IMDbID": None,
+                    "DiscordUserID": user_id1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": None,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM#NOMINATED#{film_id2}",
+                    "FilmName": "Film 2",
+                    "IMDbID": None,
+                    "DiscordUserID": user_id2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": None,
+                    "DateNominated": d.isoformat(),
+                },
+                {
+                    "SK": f"FILM#WATCHED#{(d - timedelta(days=5)).isoformat()}#{film_id3}",
+                    "FilmName": "Watched Film",
+                    "IMDbID": None,
+                    "DiscordUserID": user_id2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": {user_id2},
+                    "DateNominated": (d - timedelta(days=6)).isoformat(),
+                },
+            ]
+        }
+        set_db(self.dynamodb_client, eligible_data)
+
+        # user3: no nomination, no vote, no recent attendance
+        self.assertIsNone(filmbot.can_retire(DiscordUserID=user_id3))
+        filmbot.retire_user(DiscordUserID=user_id3)
+        db = grab_db(self.dynamodb_client)
+        user_sks = [r["SK"] for r in db[guild]]
+        self.assertNotIn(f"DISCORDUSER#{user_id3}", user_sks)
+        self.assertIn(f"DISCORDUSER#{user_id1}", user_sks)
+        self.assertIn(f"DISCORDUSER#{user_id2}", user_sks)
+        self.assertIn(f"FILM#NOMINATED#{film_id1}", user_sks)
+        self.assertIn(f"FILM#NOMINATED#{film_id2}", user_sks)
+
+        # user1: no vote, no one has voted for their film, no recent attendance
+        # Retiring user1 removes their DISCORDUSER# record and their FILM#NOMINATED# record
+        self.assertIsNone(filmbot.can_retire(DiscordUserID=user_id1))
+        filmbot.retire_user(DiscordUserID=user_id1)
+        db = grab_db(self.dynamodb_client)
+        user_sks = [r["SK"] for r in db[guild]]
+        self.assertNotIn(f"DISCORDUSER#{user_id1}", user_sks)
+        self.assertNotIn(f"FILM#NOMINATED#{film_id1}", user_sks)
+        self.assertIn(f"DISCORDUSER#{user_id2}", user_sks)
+        self.assertIn(f"FILM#NOMINATED#{film_id2}", user_sks)
+
+        # CastVotes > 0 from a previous round should not block retirement when no
+        # user currently has VoteID pointing at the film.
+        # user2 has CastVotes=3 (leftover from old rounds) but no live voters.
+        set_db(
+            self.dynamodb_client,
+            {
+                guild: [
+                    {
+                        "SK": f"DISCORDUSER#{user_id2}",
+                        "NominatedFilmID": film_id2,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                    {
+                        "SK": f"FILM#NOMINATED#{film_id2}",
+                        "FilmName": "Film 2",
+                        "IMDbID": None,
+                        "DiscordUserID": user_id2,
+                        "CastVotes": 3,  # leftover from previous rounds
+                        "AttendanceVotes": 0,
+                        "UsersAttended": None,
+                        "DateNominated": d.isoformat(),
+                    },
+                    {
+                        "SK": f"FILM#WATCHED#{(d - timedelta(days=5)).isoformat()}#{film_id3}",
+                        "FilmName": "Watched Film",
+                        "IMDbID": None,
+                        "DiscordUserID": user_id2,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": {user_id1},  # user2 not in attendance
+                        "DateNominated": (d - timedelta(days=6)).isoformat(),
+                    },
+                ]
+            },
+        )
+        self.assertIsNone(filmbot.can_retire(DiscordUserID=user_id2))
+        filmbot.retire_user(DiscordUserID=user_id2)
+        db = grab_db(self.dynamodb_client)
+        user_sks = [r["SK"] for r in db[guild]]
+        self.assertNotIn(f"DISCORDUSER#{user_id2}", user_sks)
+        self.assertNotIn(f"FILM#NOMINATED#{film_id2}", user_sks)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/register_application_commands/register_application_commands.py
+++ b/register_application_commands/register_application_commands.py
@@ -9,6 +9,7 @@
 #   - /peek
 #   - /watch
 #   - /here
+#   - /retire
 # so that they are visible and accessible within Discord.
 #
 # Usage
@@ -79,14 +80,22 @@ commands = [
         "description": "Register attendance for the film currently being watched",
     },
     {
-        "name": "naughty",
-        "type": 1,
-        "description": "Display the users with outstanding tasks",
-    },
-    {
         "name": "history",
         "type": 1,
         "description": "Display the films that have previously been watched",
+    },
+    {
+        "name": "retire",
+        "type": 1,
+        "description": "Retire a user who has been inactive",
+        "options": [
+            {
+                "name": "user",
+                "description": "The user to retire",
+                "type": 6,
+                "required": True,
+            }
+        ],
     },
 ]
 
@@ -95,4 +104,4 @@ headers = {"Authorization": f'Bot {config["bot_token"]["value"]}'}
 for command in commands:
     r = requests.post(url, headers=headers, json=command)
     print(r.json())
-    time.sleep(1)
+    time.sleep(3)


### PR DESCRIPTION
Add a way to retire inactive users.

Users that have not attended the last 5 film watches are liable to be retired.  When a user is retired, they are removed from the database, their nominated film is removed, and any cast vote is removed.

Users can unretire themselves by nominating a film.  It effectively would be the same as a new user.

Sleep for 3 seconds between registering commands instead of 1 second as it was triggering timeouts.