### PR TITLE
Attempt to deploy to AWS Lambda

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,6 +12,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build deployment package
+        run: |
+          mkdir package
+          pip install \
+            --platform manylinux2014_x86_64 \
+            --python-version 3.12 \
+            --implementation cp \
+            --only-binary=:all: \
+            -t package/ \
+            -r discord_handler/requirements.txt
+          cp discord_handler/*.py package/
+          cd package && zip -r ../deployment.zip .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy to AWS Lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --zip-file fileb://deployment.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9' # Same as used in AWS Lambda
+        python-version: '3.12' # Same as used in AWS Lambda
     - name: Install dependencies
       working-directory: ./discord_handler
       run: |


### PR DESCRIPTION
Instead of a manual process of deploying to AWS Lambda, attempt to do this automatically when we land a piece of code to `main`, in which all the unit tests pass.

Use `manylinux2014` to avoid any glibc ABI issues when building on GitHub's Ubuntu and running on AWS Linux.

We use OIDC to permission Github Actions and set up IAM permissions so it only has the permissions necessary.