### PR TITLE
Hide environment variables on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
-            --zip-file fileb://deployment.zip
+            --zip-file fileb://deployment.zip \
+            --query '{CodeSha256: CodeSha256, CodeSize: CodeSize, LastModified: LastModified, State: State, LastUpdateStatus: LastUpdateStatus}' \
+            --output table
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
By default, `aws lambda update-function-code` outputs the environment variables to the console.  This has leaked the Discord and TMDB private keys.

Both keys have been refreshed and the output of `aws` constrained to a safe subset of values.