### PR TITLE
Embed nominations in user records

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
   1. `cd discord_handler`
   2. `pip install -r dev_requirements.txt`
   3. `pip install -r requirements.txt`
-  4. `python test_filmbot.py`
+  4. `python -m unittest discover -v`
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -17,38 +17,39 @@ The partition key will be Discord Guild ID.
 
 The sort key will take one of the following forms:
   1. `"DISCORDUSER#" + DiscordUserID`
-  2. `"FILM#NOMINATED#" + FilmID`
-  3. `"FILM#WATCHED#" + DateTimeStarted + "." + FilmID`
+  2. `"FILM#WATCHED#" + DateTimeStarted + "#" + FilmID`
 
 Where:
   * `DiscordUserID` is the user's Discord ID (supplied by Discord)
   * `FilmID` is a UUID that we generate per film
-  * `DateStarted` is an ISO 8601 formatted string of the UTC datetime that
+  * `DateTimeStarted` is an ISO 8601 formatted string of the UTC datetime that
      film was started being watched
 
 For example:
   1. `"DISCORDUSER#16393729388392"`
-  2. `"FILM#NOMINATED#76988c8a-a15d-48a9-8805-5c7f1723e298"`
-  3. `"FILM#WATCHED#2022-01-19T21:35:58Z.76988c8a-a15d-48a9-8805-5c7f1723e298"`
+  2. `"FILM#WATCHED#2022-01-19T21:35:58.000000#76988c8a-a15d-48a9-8805-5c7f1723e298"`
 
 ### "DISCORDUSER#*" Record Format
 
-The records with sort key starting with `"DISCORDUSER#*"` contains the following
-fields:
-  * `NominatedFilmID` is a string matching a `"FILM#NOMINATED#*"` sort key that represents this users nominated film, or `NULL` if this user has no currently nominated film
-  * `VoteID` is a string matching a `"FILM#NOMINATED#*"` sort key that represents this user's voted film, or `NULL` if this user has not voted yet in this round
-  * `AttendanceVoteID` is a string matching a `"FILM#WATCHED#*.*"` sort key that represents this user's attendance vote for the last watched film, or `NULL` if this user did not watch the latest film
+The records with sort key starting with `"DISCORDUSER#"` contain the following fields:
+  * `VoteID` is a string matching another user's `DiscordUserID` that represents the user this person has voted for, or `NULL` if this user has not voted yet in this round
+  * `AttendanceVoteID` is a string matching a `FilmID` that represents the last film this user recorded attendance for, or `NULL` if this user has not recorded attendance for the latest watched film
 
-***WARNING*** There cannot be any entries that appear alphabetically between `DISCORDUSER#` and `FILM#NOMINATED`.  This is because we would like to get all users and all nominated films in one go in order to display what the current voting situation is.
-
-### "FILM#*" Record Format
-
-The records with sort key starting with `"FILM.*"` contains the following fields:
+When a user has an active nomination, the following additional fields are present:
+  * `FilmID` is a UUID identifying the nominated film (also used as part of the `"FILM#WATCHED#"` sort key when the film is later watched)
   * `FilmName` is a string representation of the film's name
-  * `DiscordUserID` is a string matching the users's Discord ID who nominated this film
-  * `IMDbID` is `NULL` or an IMDB ID (e.g. "0113375")
-  * `DiscordUserID` is a string matching the users's Discord ID who nominated this film
-  * `CastVotes` is a non-negative integer representing the number of votes cast for this film
+  * `IMDbID` is `NULL` or an IMDb ID (e.g. `"0113375"`)
+  * `CastVotes` is a non-negative integer representing the number of preference votes cast for this film
+  * `AttendanceVotes` is a non-negative integer representing the number of attendance votes accumulated by this user's nominations over time
+  * `DateNominated` is an ISO 8601 formatted string of the UTC datetime this film was nominated
+
+### "FILM#WATCHED#*" Record Format
+
+The records with sort key starting with `"FILM#WATCHED#"` contain the following fields:
+  * `FilmName` is a string representation of the film's name
+  * `DiscordUserID` is the Discord ID of the user who nominated this film
+  * `IMDbID` is `NULL` or an IMDb ID (e.g. `"0113375"`)
+  * `CastVotes` is a non-negative integer representing the number of preference votes the film received
   * `AttendanceVotes` is a non-negative integer representing the number of attendance votes for the user who nominated this film
-  * `UsersAttended` is `NULL` for unwatched films or a non-empty set containing the user's Discord IDs of those who have attended (DynamoDB does not support empty string sets)
-  * `DateNominated` is an ISO 8601 formatting string of the UTC datetime this film was nominated
+  * `UsersAttended` is `NULL` or a non-empty set of Discord user IDs of those who attended (DynamoDB does not support empty string sets)
+  * `DateNominated` is an ISO 8601 formatted string of the UTC datetime this film was nominated

--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -62,7 +62,7 @@ def films_to_choices(films):
         map(
             lambda n: {
                 "name": n.FilmName,
-                "value": n.FilmID,
+                "value": n.DiscordUserID,
             },
             films,
         )
@@ -239,11 +239,11 @@ def handle_application_command(event, client):
             },
         }
     elif command == "vote":
-        film_id = body["data"]["options"][0]["value"]
-        status = filmbot.cast_preference_vote(
-            DiscordUserID=user_id, FilmID=film_id
+        nominator_id = body["data"]["options"][0]["value"]
+        status, film = filmbot.cast_preference_vote(
+            DiscordUserID=user_id, NominatorUserID=nominator_id
         )
-        film_name = filmbot.get_nominated_film(film_id).FilmName
+        film_name = film.FilmName
         if status == VotingStatus.COMPLETE:
             return {
                 "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
@@ -283,7 +283,7 @@ def handle_application_command(event, client):
             )
 
             toNominate = list(
-                filter(lambda u: u["User"].NominatedFilmID is None, users)
+                filter(lambda u: not u["User"].has_nomination, users)
             )
             toVote = list(filter(lambda u: u["User"].VoteID is None, users))
 
@@ -324,9 +324,11 @@ def handle_application_command(event, client):
         return result
 
     elif command == "watch":
-        film_id = body["data"]["options"][0]["value"]
+        nominator_id = body["data"]["options"][0]["value"]
         film = filmbot.start_watching_film(
-            FilmID=film_id, DateTime=now, PresentUserIDs=[user_id]
+            NominatorUserID=nominator_id,
+            DateTime=now,
+            PresentUserIDs=[user_id],
         )
         return {
             "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
@@ -491,7 +493,7 @@ def handle_message_component(event, client):
         filmbot = FilmBot(DynamoDBClient=client, GuildID=body["guild_id"])
         users = filmbot.get_users().values()
         message = []
-        toNominate = list(filter(lambda u: u.NominatedFilmID is None, users))
+        toNominate = list(filter(lambda u: not u.has_nomination, users))
         toVote = list(filter(lambda u: u.VoteID is None, users))
 
         def display_user(user):

--- a/discord_handler/embed_nominations_migration.py
+++ b/discord_handler/embed_nominations_migration.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Migration: embeds FILM#NOMINATED data into DISCORDUSER records.
+
+Each DISCORDUSER record with a NominatedFilmID gets the corresponding film's
+data (FilmID, FilmName, IMDbID, CastVotes, AttendanceVotes, DateNominated)
+embedded directly.  VoteID (previously a bare film ID) is replaced by the
+nominator's Discord user ID.  After migrating, FILM#NOMINATED records and
+NominatedFilmID fields are removed.
+
+Run with --dry-run to preview changes without modifying the database.
+"""
+
+import argparse
+import boto3
+
+TABLE_NAME = "FilmBotTable"
+
+
+def migrate(client, dry_run):
+    # Scan the full table (paginating in case of large datasets)
+    items = []
+    kwargs = {"TableName": TABLE_NAME}
+    while True:
+        response = client.scan(**kwargs)
+        items.extend(response["Items"])
+        if "LastEvaluatedKey" not in response:
+            break
+        kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+
+    # Group by GuildID (PK), separating user records from nominated film records
+    guilds = {}
+    for item in items:
+        guild_id = item["PK"]["S"]
+        if guild_id not in guilds:
+            guilds[guild_id] = {"users": {}, "nominated": {}}
+        sk = item["SK"]["S"]
+        if sk.startswith("DISCORDUSER#"):
+            guilds[guild_id]["users"][sk.removeprefix("DISCORDUSER#")] = item
+        elif sk.startswith("FILM#NOMINATED#"):
+            guilds[guild_id]["nominated"][
+                sk.removeprefix("FILM#NOMINATED#")
+            ] = item
+
+    for guild_id, data in guilds.items():
+        users = data["users"]
+        nominated = data["nominated"]
+
+        if not nominated:
+            continue
+
+        # Build film_id → nominator_user_id mapping from the nominated film records
+        film_to_nominator = {
+            film_id: film["DiscordUserID"]["S"]
+            for film_id, film in nominated.items()
+        }
+
+        transact_items = []
+
+        for user_id, user in users.items():
+            set_exprs = []
+            remove_exprs = []
+            expr_attr_values = {}
+
+            # Embed film data if this user has an active nomination
+            nominated_film_id = user.get("NominatedFilmID", {}).get("S")
+            if nominated_film_id:
+                film = nominated.get(nominated_film_id)
+                if film:
+                    set_exprs += [
+                        "FilmID = :FilmID",
+                        "FilmName = :FilmName",
+                        "IMDbID = :IMDbID",
+                        "CastVotes = :CastVotes",
+                        "AttendanceVotes = :AttendanceVotes",
+                        "DateNominated = :DateNominated",
+                    ]
+                    expr_attr_values.update(
+                        {
+                            ":FilmID": {"S": nominated_film_id},
+                            ":FilmName": film["FilmName"],
+                            ":IMDbID": film.get("IMDbID", {"NULL": True}),
+                            ":CastVotes": film["CastVotes"],
+                            ":AttendanceVotes": film["AttendanceVotes"],
+                            ":DateNominated": film["DateNominated"],
+                        }
+                    )
+                else:
+                    print(
+                        f"[{guild_id}] WARNING: user {user_id} references "
+                        f"film {nominated_film_id} which has no FILM#NOMINATED# record"
+                    )
+
+            # Remove NominatedFilmID (replaced by the embedded fields above)
+            if "NominatedFilmID" in user:
+                remove_exprs.append("NominatedFilmID")
+
+            # Update VoteID from a bare film ID to the nominator's DiscordUserID
+            vote_film_id = user.get("VoteID", {}).get("S")
+            if vote_film_id:
+                nominator_id = film_to_nominator.get(vote_film_id)
+                if nominator_id:
+                    set_exprs.append("VoteID = :VoteID")
+                    expr_attr_values[":VoteID"] = {"S": nominator_id}
+                else:
+                    print(
+                        f"[{guild_id}] WARNING: user {user_id} voted for film "
+                        f"{vote_film_id} which has no nominator — clearing vote"
+                    )
+                    set_exprs.append("VoteID = :Null")
+                    expr_attr_values[":Null"] = {"NULL": True}
+
+            if not set_exprs and not remove_exprs:
+                continue
+
+            update_expr = ""
+            if set_exprs:
+                update_expr += "SET " + ", ".join(set_exprs)
+            if remove_exprs:
+                update_expr += (
+                    (" " if update_expr else "")
+                    + "REMOVE "
+                    + ", ".join(remove_exprs)
+                )
+
+            op = {
+                "Update": {
+                    "TableName": TABLE_NAME,
+                    "Key": {
+                        "PK": {"S": guild_id},
+                        "SK": {"S": f"DISCORDUSER#{user_id}"},
+                    },
+                    "UpdateExpression": update_expr,
+                }
+            }
+            if expr_attr_values:
+                op["Update"]["ExpressionAttributeValues"] = expr_attr_values
+            transact_items.append(op)
+
+        # Delete all FILM#NOMINATED# records
+        for film_id in nominated:
+            transact_items.append(
+                {
+                    "Delete": {
+                        "TableName": TABLE_NAME,
+                        "Key": {
+                            "PK": {"S": guild_id},
+                            "SK": {"S": f"FILM#NOMINATED#{film_id}"},
+                        },
+                    }
+                }
+            )
+
+        if dry_run:
+            print(
+                f"[{guild_id}] Dry run - {len(transact_items)} operation(s):"
+            )
+            for op in transact_items:
+                kind = next(iter(op))
+                key = op[kind]["Key"]["SK"]["S"]
+                print(f"  {kind}: {key}")
+        else:
+            # transact_write_items supports up to 100 items per call; split if needed
+            for i in range(0, len(transact_items), 100):
+                client.transact_write_items(
+                    TransactItems=transact_items[i : i + 100]
+                )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate FilmBot DynamoDB table to embed nominations in user records."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without writing to the database",
+    )
+    parser.add_argument(
+        "--endpoint-url",
+        help="DynamoDB endpoint URL (e.g. http://localhost:8000 for local testing)",
+    )
+    args = parser.parse_args()
+
+    kwargs = {}
+    if args.endpoint_url:
+        kwargs["endpoint_url"] = args.endpoint_url
+
+    client = boto3.client("dynamodb", **kwargs)
+    migrate(client, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -7,7 +7,6 @@ TABLE_NAME = "FilmBotTable"
 
 USER_PK = "PK"
 USER_SK = "SK"
-USER_NominatedFilmID = "NominatedFilmID"
 USER_VoteID = "VoteID"
 USER_AttendanceVoteID = "AttendanceVoteID"
 
@@ -28,14 +27,28 @@ class User:
         self,
         *,
         DiscordUserID,
-        NominatedFilmID,
         VoteID,
         AttendanceVoteID,
+        FilmID=None,
+        FilmName=None,
+        IMDbID=None,
+        CastVotes=None,
+        AttendanceVotes=None,
+        DateNominated=None,
     ):
         self.DiscordUserID = DiscordUserID
-        self.NominatedFilmID = NominatedFilmID
         self.VoteID = VoteID
         self.AttendanceVoteID = AttendanceVoteID
+        self.FilmID = FilmID
+        self.FilmName = FilmName
+        self.IMDbID = IMDbID
+        self.CastVotes = CastVotes
+        self.AttendanceVotes = AttendanceVotes
+        self.DateNominated = DateNominated
+
+    @property
+    def has_nomination(self):
+        return self.FilmName is not None
 
     @property
     def SK(self):
@@ -44,30 +57,58 @@ class User:
     def __eq__(self, other):
         return (
             self.DiscordUserID == other.DiscordUserID
-            and self.NominatedFilmID == other.NominatedFilmID
             and self.VoteID == other.VoteID
             and self.AttendanceVoteID == other.AttendanceVoteID
+            and self.FilmID == other.FilmID
+            and self.FilmName == other.FilmName
+            and self.IMDbID == other.IMDbID
+            and self.CastVotes == other.CastVotes
+            and self.AttendanceVotes == other.AttendanceVotes
+            and self.DateNominated == other.DateNominated
         )
 
     def __hash__(self):
         return hash(self.DiscordUserID)
 
     def toDict(self, *, GuildID):
-        return {
+        d = {
             "PK": {"S": GuildID},
             "SK": {"S": self.SK},
-            "NominatedFilmID": keyed(self.NominatedFilmID),
             "VoteID": keyed(self.VoteID),
             "AttendanceVoteID": keyed(self.AttendanceVoteID),
         }
+        if self.has_nomination:
+            d["FilmID"] = {"S": self.FilmID}
+            d["FilmName"] = {"S": self.FilmName}
+            d["IMDbID"] = keyed(self.IMDbID)
+            d["CastVotes"] = {"N": str(self.CastVotes)}
+            d["AttendanceVotes"] = {"N": str(self.AttendanceVotes)}
+            d["DateNominated"] = {"S": datetime.isoformat(self.DateNominated)}
+        return d
 
     @staticmethod
-    def fromDict(dict):
+    def fromDict(item):
+        film_name = unkeyed(item["FilmName"]) if "FilmName" in item else None
         return User(
-            DiscordUserID=dict[USER_SK]["S"].split("#")[-1],
-            NominatedFilmID=unkeyed(dict[USER_NominatedFilmID]),
-            VoteID=unkeyed(dict[USER_VoteID]),
-            AttendanceVoteID=unkeyed(dict[USER_AttendanceVoteID]),
+            DiscordUserID=item[USER_SK]["S"].split("#")[-1],
+            VoteID=unkeyed(item[USER_VoteID]),
+            AttendanceVoteID=unkeyed(item[USER_AttendanceVoteID]),
+            FilmID=unkeyed(item["FilmID"]) if "FilmID" in item else None,
+            FilmName=film_name,
+            IMDbID=unkeyed(item["IMDbID"]) if "IMDbID" in item else None,
+            CastVotes=(
+                unkeyed(item["CastVotes"]) if "CastVotes" in item else None
+            ),
+            AttendanceVotes=(
+                unkeyed(item["AttendanceVotes"])
+                if "AttendanceVotes" in item
+                else None
+            ),
+            DateNominated=(
+                datetime.fromisoformat(unkeyed(item["DateNominated"]))
+                if "DateNominated" in item
+                else None
+            ),
         )
 
 
@@ -259,6 +300,21 @@ class AttendanceStatus(Enum):
     ALREADY_REGISTERED = 1
 
 
+def _user_to_film(user):
+    """Construct a nominated Film object from a User record."""
+    return Film(
+        FilmID=user.FilmID,
+        FilmName=user.FilmName,
+        IMDbID=user.IMDbID,
+        DiscordUserID=user.DiscordUserID,
+        CastVotes=user.CastVotes,
+        AttendanceVotes=user.AttendanceVotes,
+        UsersAttended=None,
+        DateNominated=user.DateNominated,
+        DateWatched=None,
+    )
+
+
 class FilmBot:
     def __init__(self, DynamoDBClient, GuildID):
         self._dynamodb_client = DynamoDBClient
@@ -311,48 +367,16 @@ class FilmBot:
 
         return {user.DiscordUserID: user for user in users}
 
-    def get_nominated_film(self, FilmID):
-        """
-        Return a `Film` object for the nominated film with the specified `FilmID`.
-        Throw an exception if there isn't a nominated film associated with
-        `FilmID`.
-        """
-        response = self.client.get_item(
-            TableName=TABLE_NAME,
-            Key={
-                FILM_PK: {"S": self.guildID},
-                FILM_SK: {"S": f"FILM#NOMINATED#{FilmID}"},
-            },
-        )
-
-        if "Item" not in response:
-            raise UserError(
-                f"There is no nominated film with that ID ({FilmID})"
-            )
-
-        return Film.fromDict(response["Item"])
-
     def get_nominations(self):
         """Return an array of currently nominated films in the order that they should
         be watched based on their vote tally."""
 
-        nominations = map(
-            Film.fromDict,
-            self.__query(
-                {
-                    "TableName": TABLE_NAME,
-                    "ExpressionAttributeValues": {
-                        ":GuildID": {"S": self.guildID},
-                        ":FilmPrefix": {"S": "FILM#NOMINATED#"},
-                    },
-                    "KeyConditionExpression": (
-                        f"{FILM_PK} = :GuildID AND "
-                        f"begins_with({FILM_SK}, :FilmPrefix)"
-                    ),
-                }
-            ),
-        )
-
+        users = self.get_users()
+        nominations = [
+            _user_to_film(user)
+            for user in users.values()
+            if user.has_nomination
+        ]
         return sorted(nominations, key=Film.sortKey)
 
     def get_users_by_nomination(self):
@@ -361,50 +385,17 @@ class FilmBot:
         If a user has not nominated then they will be put at the end of the array.
         """
 
-        # Probably we should be duplicating film data under the user instead of using
-        # NoSQL in a relational way.  But in this case we can grab all users and all
-        # nominations easily and do the mapping ourselves.
-
-        films = {}
-        users = []
-        for result in self.__query(
+        users = self.get_users()
+        result = [
             {
-                "TableName": TABLE_NAME,
-                "ExpressionAttributeValues": {
-                    ":GuildID": {"S": self.guildID},
-                    ":UserPrefix": {"S": "DISCORDUSER#"},
-                    ":FilmPrefix": {"S": "FILM#NOMINATED$"},  # '$' == '#' + 1
-                },
-                "KeyConditionExpression": (
-                    f"{FILM_PK} = :GuildID AND "
-                    f"{FILM_SK} BETWEEN :UserPrefix AND :FilmPrefix"
-                ),
-                "ScanIndexForward": False,  # Backwards so we get films first
+                "User": user,
+                "Film": _user_to_film(user) if user.has_nomination else None,
             }
-        ):
-            sk_parts = result[FILM_SK]["S"].split("#")
-            if sk_parts[0] == "FILM":
-                assert sk_parts[1] == "NOMINATED"
-                films[sk_parts[-1]] = Film.fromDict(result)
-            elif sk_parts[0] == "DISCORDUSER":
-                # At this point we should have populated all the films so we can lookup
-                # `NominatedFilmID` in `films`
-                user = User.fromDict(result)
-                users.append(
-                    {
-                        "User": user,
-                        "Film": (
-                            films[user.NominatedFilmID]
-                            if user.NominatedFilmID is not None
-                            else None
-                        ),
-                    }
-                )
-            else:
-                assert False
+            for user in users.values()
+        ]
 
         return sorted(
-            users,
+            result,
             key=lambda u: (
                 (0, Film.sortKey(u["Film"]))
                 if u["Film"] is not None
@@ -476,23 +467,13 @@ class FilmBot:
         Return an array watched and unwatched films in the order that they were
         nominated.
         """
-        films = map(
-            Film.fromDict,
-            self.__query(
-                {
-                    "TableName": TABLE_NAME,
-                    "ExpressionAttributeValues": {
-                        ":GuildID": {"S": self.guildID},
-                        ":FilmPrefix": {"S": "FILM#"},
-                    },
-                    "KeyConditionExpression": (
-                        f"{FILM_PK} = :GuildID AND "
-                        f"begins_with({FILM_SK}, :FilmPrefix)"
-                    ),
-                }
-            ),
-        )
-
+        users = self.get_users()
+        films = [
+            _user_to_film(user)
+            for user in users.values()
+            if user.has_nomination
+        ]
+        films += self.get_watched_films()
         return sorted(films, key=lambda n: n.DateNominated)
 
     def nominate_film(
@@ -511,19 +492,6 @@ class FilmBot:
         `DiscordUserID` already has a nomination then throw an exception.
         """
 
-        new_film = Film(
-            FilmID=NewFilmID,
-            FilmName=FilmName,
-            IMDbID=IMDbID,
-            DiscordUserID=DiscordUserID,
-            CastVotes=0,
-            AttendanceVotes=0,
-            # Empty string sets are not allowed so we have to use None
-            UsersAttended=None,
-            DateNominated=DateTime,
-            DateWatched=None,
-        )
-
         try:
             self.client.transact_write_items(
                 TransactItems=[
@@ -536,45 +504,44 @@ class FilmBot:
                             },
                             "ExpressionAttributeValues": {
                                 ":NewFilmID": {"S": NewFilmID},
+                                ":FilmName": {"S": FilmName},
+                                ":IMDbID": keyed(IMDbID),
+                                ":Zero": {"N": "0"},
+                                ":DateNominated": {
+                                    "S": datetime.isoformat(DateTime)
+                                },
                                 ":Null": {"NULL": True},
                             },
-                            "ConditionExpression": (
-                                f"attribute_not_exists({USER_SK}) OR "
-                                f"{USER_NominatedFilmID} = :Null"
-                            ),
-                            # Make sure to null out the other fields in case we didn't have a user yet
-                            # These should both be Null at this point as we can only nominate after we
-                            # watch a film and these are cleared
+                            "ConditionExpression": "attribute_not_exists(FilmName)",
+                            # Make sure to null out VoteID and AttendanceVoteID in case we
+                            # didn't have a user yet. These should both be Null at this point
+                            # as we can only nominate after we watch a film and these are cleared.
                             "UpdateExpression": (
-                                f"SET {USER_NominatedFilmID} = :NewFilmID, "
+                                "SET FilmID = :NewFilmID, "
+                                "FilmName = :FilmName, "
+                                "IMDbID = :IMDbID, "
+                                "CastVotes = :Zero, "
+                                "AttendanceVotes = :Zero, "
+                                "DateNominated = :DateNominated, "
                                 f"{USER_VoteID} = :Null, "
                                 f"{USER_AttendanceVoteID} = :Null"
                             ),
                         }
                     },
-                    {
-                        "Put": {
-                            "TableName": TABLE_NAME,
-                            "Item": new_film.toDict(GuildID=self.guildID),
-                            # Make sure we haven't reused this film ID before
-                            "ConditionExpression": f"attribute_not_exists({FILM_SK})",
-                        }
-                    },
                 ]
             )
         except self.client.exceptions.TransactionCanceledException as e:
-            # This can also occur if we pass in a reused FilmID, but that is
-            # impossible if we're using a UUID properly.
             raise UserError(
                 "Unable to nominate a film as you have already nominated one"
             )
 
-    def cast_preference_vote(self, *, DiscordUserID, FilmID):
+    def cast_preference_vote(self, *, DiscordUserID, NominatorUserID):
         """
-        Attempt to cast a vote for `FilmID` by `DiscordUserID` and return
-        whether voting is complete.  Throw an exception if either
-        `DiscordUserID` is not a registered user, FilmID` refers to that
-        user's nominated film, or `FilmID` doesn't point to a nominated film.
+        Attempt to cast a vote for the film nominated by `NominatorUserID` on behalf
+        of `DiscordUserID` and return a tuple of (VotingStatus, Film).  Throw an
+        exception if `DiscordUserID` is not a registered user, `NominatorUserID`
+        refers to that user themselves, or `NominatorUserID` doesn't have an active
+        nomination.
         """
 
         users = self.get_users()
@@ -582,10 +549,12 @@ class FilmBot:
             raise UserError("You can't vote until you have nominated a film")
 
         our_user = users[DiscordUserID]
-        previous_vote = our_user.VoteID
+        previous_vote = (
+            our_user.VoteID
+        )  # NominatorUserID of previously voted film
 
         # Disallow voting for your own nomination
-        if FilmID == our_user.NominatedFilmID:
+        if NominatorUserID == DiscordUserID:
             raise UserError("You can't vote for your own film")
 
         # Record if this is the last user to vote
@@ -594,12 +563,12 @@ class FilmBot:
         our_user_hasnt_voted = our_user.VoteID is None
 
         # Do nothing if user votes for the same thing
-        if previous_vote == FilmID:
+        if previous_vote == NominatorUserID:
             return (
                 VotingStatus.COMPLETE
                 if user_voted_count == len(user_list)
                 else VotingStatus.UNCOMPLETE
-            )
+            ), _user_to_film(users[NominatorUserID])
 
         items = [
             # Change vote-id and make sure it matches the one we previously read
@@ -612,97 +581,115 @@ class FilmBot:
                         USER_SK: {"S": f"DISCORDUSER#{DiscordUserID}"},
                     },
                     "ExpressionAttributeValues": {
-                        ":NewFilmID": {"S": FilmID},
+                        ":NewVoteID": {"S": NominatorUserID},
                         ":PreviousVoteID": keyed(previous_vote),
                     },
                     "ConditionExpression": (
                         f"attribute_exists({USER_SK}) AND "
                         f"{USER_VoteID} = :PreviousVoteID"
                     ),
-                    "UpdateExpression": f"SET {USER_VoteID} = :NewFilmID",
+                    "UpdateExpression": f"SET {USER_VoteID} = :NewVoteID",
                 }
             },
-            # Increment vote count in nominations for new film (also check it exists)
+            # Increment vote count on the nominator's user record (also check they have a nomination)
             {
                 "Update": {
                     "TableName": TABLE_NAME,
                     "Key": {
-                        FILM_PK: {"S": self.guildID},
-                        FILM_SK: {"S": f"FILM#NOMINATED#{FilmID}"},
+                        USER_PK: {"S": self.guildID},
+                        USER_SK: {"S": f"DISCORDUSER#{NominatorUserID}"},
                     },
                     "ExpressionAttributeValues": {
                         ":One": {"N": "1"},
                     },
-                    "ConditionExpression": f"attribute_exists({FILM_SK})",
-                    "UpdateExpression": f"SET {FILM_CastVotes} = {FILM_CastVotes} + :One",
+                    "ConditionExpression": "attribute_exists(FilmName)",
+                    "UpdateExpression": "SET CastVotes = CastVotes + :One",
                 }
             },
         ]
 
         if previous_vote is not None:
-            # Decrement vote count for previous film
+            # Decrement vote count on previous nominator's record
             items.append(
                 {
                     "Update": {
                         "TableName": TABLE_NAME,
                         "Key": {
-                            FILM_PK: {"S": self.guildID},
-                            FILM_SK: {"S": f"FILM#NOMINATED#{previous_vote}"},
+                            USER_PK: {"S": self.guildID},
+                            USER_SK: {"S": f"DISCORDUSER#{previous_vote}"},
                         },
                         "ExpressionAttributeValues": {
                             ":One": {"N": "1"},
                         },
-                        # We don't need a ConditionExpression as we should never be updating
-                        # something that wasn't in the table
-                        "UpdateExpression": f"SET {FILM_CastVotes} = {FILM_CastVotes} - :One",
+                        "ConditionExpression": "attribute_exists(FilmName)",
+                        "UpdateExpression": "SET CastVotes = CastVotes - :One",
                     }
                 }
             )
 
-        # The transaction can also throw if the user votes quickly in
-        # succession so updating our users table fails because the
-        # current film we voted on doesn't match what we previously
-        # extracted.  This is unlikely to occur as the only sensible way
-        # to know the `FilmID` is to use the Discord autocomplete, which
-        # takes time to load.
         try:
             self.client.transact_write_items(TransactItems=items)
-        except self.client.exceptions.TransactionCanceledException:
+        except self.client.exceptions.TransactionCanceledException as e:
+            reasons = e.response.get("CancellationReasons", [])
+            failed = {
+                i
+                for i, r in enumerate(reasons)
+                if r.get("Code") == "ConditionalCheckFailed"
+            }
+            if 0 in failed:
+                raise UserError(
+                    "Your vote could not be recorded due to a conflict, please try again"
+                )
+            if 1 in failed:
+                raise UserError(
+                    f"There is no film nominated by <@{NominatorUserID}>"
+                )
+            if 2 in failed:
+                raise UserError(
+                    "The film you were changing your vote away from has just been watched - please vote again"
+                )
             raise UserError(
-                f"There is no nominated film with that ID ({FilmID})"
+                "Unknown error occurred while recording your vote, please try again"
             )
 
         return (
             VotingStatus.COMPLETE
             if user_voted_count + int(our_user_hasnt_voted) == len(user_list)
             else VotingStatus.UNCOMPLETE
-        )
+        ), _user_to_film(users[NominatorUserID])
 
-    def start_watching_film(self, *, FilmID, PresentUserIDs, DateTime):
+    def start_watching_film(
+        self, *, NominatorUserID, PresentUserIDs, DateTime
+    ):
         """
-        Attempt to record that we're watching the specified `FilmID` and
-        record an attendance vote for each user in the `PresentUserIDs` array
-        and return the a `Film` object.  Also clear out all cast votes
-        from all users and clear out the user's nomination who had previously
-        nominated `FilmID`.  Throw an exception if `FilmID` isn't correct,
-        less than 24 hours has passed since watching the last film, or
-        `PresentUserIDs` is empty.
+        Attempt to record that we're watching the film nominated by `NominatorUserID`
+        and record an attendance vote for each user in the `PresentUserIDs` array
+        and return the a `Film` object.  Also clear out all cast votes from all users
+        and clear the nomination from the user who nominated the film.  Throw an
+        exception if `NominatorUserID` doesn't have an active nomination, less than
+        24 hours has passed since watching the last film, or `PresentUserIDs` is empty.
         """
 
-        # At least one user must be present to start watching a film"
+        # At least one user must be present to start watching a film
         assert PresentUserIDs
 
         response = self.client.get_item(
             TableName=TABLE_NAME,
             Key={
-                FILM_PK: {"S": self.guildID},
-                FILM_SK: {"S": f"FILM#NOMINATED#{FilmID}"},
+                USER_PK: {"S": self.guildID},
+                USER_SK: {"S": f"DISCORDUSER#{NominatorUserID}"},
             },
         )
 
         if "Item" not in response:
             raise UserError(
-                f"There is no nominated film with that ID ({FilmID})"
+                f"There is no film nominated by <@{NominatorUserID}>"
+            )
+
+        nominator_user = User.fromDict(response["Item"])
+        if not nominator_user.has_nomination:
+            raise UserError(
+                f"There is no film nominated by <@{NominatorUserID}>"
             )
 
         # Check to see all user IDs are valid
@@ -710,8 +697,7 @@ class FilmBot:
         for user in PresentUserIDs:
             assert user in all_users
 
-        film = Film.fromDict(response["Item"])
-        nominator_user_id = film.DiscordUserID
+        film = _user_to_film(nominator_user)
 
         # Get the last film watched and see if enough time has passed
         response = self.client.query(
@@ -741,20 +727,55 @@ class FilmBot:
             # Either reset our vote if we aren't present, or set it to
             # the current film ID if we are
             attendance_vote = (
-                {"S": FilmID} if user_id in PresentUserIDs else {"NULL": True}
+                {"S": film.FilmID}
+                if user_id in PresentUserIDs
+                else {"NULL": True}
             )
 
             user = all_users[user_id]
 
-            # Clear our out votes
-            update_exprs = [
+            set_exprs = [
                 f"{USER_VoteID} = :Null",
                 f"{USER_AttendanceVoteID} = :AttendanceVote",
             ]
+            remove_exprs = []
+            add_exprs = []
 
-            # If this was our film, clear our nomination
-            if user_id == nominator_user_id:
-                update_exprs.append(f"{USER_NominatedFilmID} = :Null")
+            if user_id == NominatorUserID:
+                # Clear embedded film fields from the nominator's record
+                remove_exprs += [
+                    "FilmID",
+                    "FilmName",
+                    "IMDbID",
+                    "CastVotes",
+                    "AttendanceVotes",
+                    "DateNominated",
+                ]
+
+            if (
+                user_id in PresentUserIDs
+                and user_id != NominatorUserID
+                and user.has_nomination
+            ):
+                add_exprs.append("AttendanceVotes :One")
+
+            update_expr = "SET " + ", ".join(set_exprs)
+            if remove_exprs:
+                update_expr += " REMOVE " + ", ".join(remove_exprs)
+
+            expr_attr_values = {
+                ":Null": {"NULL": True},
+                ":AttendanceVote": attendance_vote,
+            }
+            if add_exprs:
+                update_expr += " ADD " + ", ".join(add_exprs)
+                expr_attr_values[":One"] = {"N": "1"}
+
+            if user.has_nomination:
+                condition = "FilmID = :PreviousFilmID"
+                expr_attr_values[":PreviousFilmID"] = {"S": user.FilmID}
+            else:
+                condition = "attribute_not_exists(FilmName)"
 
             items.append(
                 {
@@ -764,66 +785,23 @@ class FilmBot:
                             USER_PK: {"S": self.guildID},
                             USER_SK: {"S": f"DISCORDUSER#{user_id}"},
                         },
-                        "ExpressionAttributeValues": {
-                            ":Null": {"NULL": True},
-                            ":PreviousNomination": keyed(user.NominatedFilmID),
-                            ":AttendanceVote": attendance_vote,
-                        },
-                        # We have already checked that the user exists
-                        "ConditionExpression": f"{USER_NominatedFilmID} = :PreviousNomination",
-                        "UpdateExpression": "SET " + ", ".join(update_exprs),
+                        "ExpressionAttributeValues": expr_attr_values,
+                        "ConditionExpression": condition,
+                        "UpdateExpression": update_expr,
                     }
                 }
             )
 
-            # Add an attendance vote for all present users as long
-            # as we weren't the one who nominated the film being
-            # watched and we also have a nominated film
-            if (
-                user_id in PresentUserIDs
-                and user_id != nominator_user_id
-                and user.NominatedFilmID is not None
-            ):
-                items.append(
-                    {
-                        "Update": {
-                            "TableName": TABLE_NAME,
-                            "Key": {
-                                FILM_PK: {"S": self.guildID},
-                                FILM_SK: {
-                                    "S": f"FILM#NOMINATED#{user.NominatedFilmID}"
-                                },
-                            },
-                            "ExpressionAttributeValues": {
-                                ":One": {"N": "1"},
-                            },
-                            "UpdateExpression": f"ADD {FILM_AttendanceVotes} :One",
-                        }
-                    }
-                )
-
         film.DateWatched = DateTime
         film.UsersAttended = set(PresentUserIDs)
-        items += [
-            {
-                "Delete": {
-                    "TableName": TABLE_NAME,
-                    "Key": {
-                        FILM_PK: {"S": self.guildID},
-                        FILM_SK: {"S": f"FILM#NOMINATED#{FilmID}"},
-                    },
-                    # Make sure the film still exists to defend against this
-                    # function being called multiple times in quick succession
-                    "ConditionExpression": f"attribute_exists({FILM_SK})",
-                }
-            },
+        items.append(
             {
                 "Put": {
                     "TableName": TABLE_NAME,
                     "Item": film.toDict(GuildID=self.guildID),
                 },
-            },
-        ]
+            }
+        )
         self.client.transact_write_items(TransactItems=items)
 
         return film
@@ -834,7 +812,7 @@ class FilmBot:
           - ``reason`` is ``None`` when the user is eligible, or a human-readable
             string (suitable for passing to `UserError`) explaining why they are not.
           - ``nominated_film`` is the ``Film`` record for their current nomination, or ``None`` if they
-            have no nomination or the nominated film record no longer exists.
+            have no nomination.
         """
         response = self.client.get_item(
             TableName=TABLE_NAME,
@@ -855,30 +833,18 @@ class FilmBot:
             )
 
         nominated_film = None
-        if user.NominatedFilmID is not None:
-            film_response = self.client.get_item(
-                TableName=TABLE_NAME,
-                Key={
-                    FILM_PK: {"S": self.guildID},
-                    FILM_SK: {"S": f"FILM#NOMINATED#{user.NominatedFilmID}"},
-                },
-            )
-            nominated_film = (
-                Film.fromDict(film_response["Item"])
-                if "Item" in film_response
-                else None
-            )
-            if nominated_film is not None:
-                all_users = self.get_users()
-                for other_user_id, other_user in all_users.items():
-                    if (
-                        other_user_id != DiscordUserID
-                        and other_user.VoteID == user.NominatedFilmID
-                    ):
-                        return (
-                            f"<@{DiscordUserID}> cannot be retired as other users have voted for their film",
-                            None,
-                        )
+        if user.has_nomination:
+            nominated_film = _user_to_film(user)
+            all_users = self.get_users()
+            for other_user_id, other_user in all_users.items():
+                if (
+                    other_user_id != DiscordUserID
+                    and other_user.VoteID == DiscordUserID
+                ):
+                    return (
+                        f"<@{DiscordUserID}> cannot be retired as other users have voted for their film",
+                        None,
+                    )
 
         # Watched film records are immutable once written, so this read is
         # not subject to a race condition.
@@ -923,9 +889,9 @@ class FilmBot:
     def retire_user(self, *, DiscordUserID):
         """
         Attempt to retire the specified `DiscordUserID` by removing their
-        user record and, if they have a nomination, their
-        corresponding nomination record.  Throw an exception if the user is not
-        registered or any of the following hold:
+        user record (which also removes their nomination if they have one).
+        Throw an exception if the user is not registered or any of the
+        following hold:
           - They attended any of the last 5 watched films.
           - They have cast a preference vote.
           - Another user currently has a vote for their nomination.
@@ -936,51 +902,35 @@ class FilmBot:
         if reason is not None:
             raise UserError(reason)
 
-        items = [
-            {
-                "Delete": {
-                    "TableName": TABLE_NAME,
-                    "Key": {
-                        USER_PK: {"S": self.guildID},
-                        USER_SK: {"S": f"DISCORDUSER#{DiscordUserID}"},
-                    },
-                    # Guard against the user casting a vote between our read
-                    # and this commit.
-                    "ConditionExpression": f"{USER_VoteID} = :Null",
-                    "ExpressionAttributeValues": {
-                        ":Null": {"NULL": True},
-                    },
-                }
-            }
-        ]
+        condition = f"{USER_VoteID} = :Null"
+        expr_attr_values = {":Null": {"NULL": True}}
 
         if nominated_film is not None:
-            items.append(
-                {
-                    "Delete": {
-                        "TableName": TABLE_NAME,
-                        "Key": {
-                            FILM_PK: {"S": self.guildID},
-                            FILM_SK: {
-                                "S": f"FILM#NOMINATED#{nominated_film.FilmID}"
-                            },
-                        },
-                        # Guard against any user voting for this film between
-                        # our read and this commit.  Since we have already checked no one
-                        # voted for this film, the only thing that can change this value
-                        # is someone voting for it.
-                        "ConditionExpression": f"{FILM_CastVotes} = :ReadCastVotes",
-                        "ExpressionAttributeValues": {
-                            ":ReadCastVotes": {
-                                "N": str(nominated_film.CastVotes)
-                            },
-                        },
-                    }
-                }
-            )
+            # Guard against any user voting for this film between our read
+            # and this commit. Since we have already checked no one voted
+            # for this film, the only thing that can change CastVotes is
+            # someone voting for it.
+            condition += " AND CastVotes = :ReadCastVotes"
+            expr_attr_values[":ReadCastVotes"] = {
+                "N": str(nominated_film.CastVotes)
+            }
 
         try:
-            self.client.transact_write_items(TransactItems=items)
+            self.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Delete": {
+                            "TableName": TABLE_NAME,
+                            "Key": {
+                                USER_PK: {"S": self.guildID},
+                                USER_SK: {"S": f"DISCORDUSER#{DiscordUserID}"},
+                            },
+                            "ConditionExpression": condition,
+                            "ExpressionAttributeValues": expr_attr_values,
+                        }
+                    }
+                ]
+            )
         except self.client.exceptions.TransactionCanceledException:
             raise UserError(
                 f"Unable to retire <@{DiscordUserID}>. Please try again."
@@ -1047,22 +997,39 @@ class FilmBot:
                 f"The cutoff for registering attendance was {end_time}"
             )
 
+        # Build the update expression for the user's record, optionally
+        # incrementing their nomination's AttendanceVotes in the same write.
+        update_expr = f"SET {USER_AttendanceVoteID} = :AttendanceVote"
+        expr_attr_values = {
+            ":Null": {"NULL": True},
+            ":AttendanceVote": {"S": latest_watched_film.FilmID},
+        }
+
+        # Add an attendance vote if we weren't the user who nominated the film
+        # and we have a nomination.  We must check both as we could either nominate
+        # straight after we start watching our film or we could have failed to nominate
+        # a new film before a second film has started being watched.
+        if (
+            latest_watched_film.DiscordUserID != user.DiscordUserID
+            and user.has_nomination
+        ):
+            update_expr += " ADD AttendanceVotes :One"
+            expr_attr_values[":One"] = {"N": "1"}
+
         items = [
             {
-                # Record that the user has an attendance vote
+                # Record that the user has an attendance vote, and optionally
+                # increment their film's attendance votes.
                 "Update": {
                     "TableName": TABLE_NAME,
                     "Key": {
                         USER_PK: {"S": self.guildID},
                         USER_SK: {"S": user.SK},
                     },
-                    "ExpressionAttributeValues": {
-                        ":Null": {"NULL": True},
-                        ":AttendanceVote": {"S": latest_watched_film.FilmID},
-                    },
+                    "ExpressionAttributeValues": expr_attr_values,
                     # Check that we haven't recorded an attendance in the meantime
                     "ConditionExpression": f"{USER_AttendanceVoteID} = :Null",
-                    "UpdateExpression": f"SET {USER_AttendanceVoteID} = :AttendanceVote",
+                    "UpdateExpression": update_expr,
                 }
             },
             {
@@ -1081,30 +1048,5 @@ class FilmBot:
             },
         ]
 
-        # Add an attendance vote if we weren't the user who nominated the film
-        # and we have a nomination.  We must check both as we could either nominate
-        # straight after we start watching our film or we could have failed to nominate
-        # a new film before a second film has started being watched
-        if (
-            latest_watched_film.DiscordUserID != user.DiscordUserID
-            and user.NominatedFilmID is not None
-        ):
-            items.append(
-                {
-                    "Update": {
-                        "TableName": TABLE_NAME,
-                        "Key": {
-                            FILM_PK: {"S": self.guildID},
-                            FILM_SK: {
-                                "S": f"FILM#NOMINATED#{user.NominatedFilmID}"
-                            },
-                        },
-                        "ExpressionAttributeValues": {
-                            ":One": {"N": "1"},
-                        },
-                        "UpdateExpression": f"ADD {FILM_AttendanceVotes} :One",
-                    }
-                }
-            )
         self.client.transact_write_items(TransactItems=items)
         return AttendanceStatus.REGISTERED

--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -16,6 +16,7 @@ from filmbot import (
 from datetime import datetime, timedelta
 from uuid import uuid1
 from UserError import UserError
+from embed_nominations_migration import migrate
 import copy
 
 AWS_REGION = "eu-west-2"
@@ -71,6 +72,7 @@ def set_db(client, data):
     )
 
     if not data:
+        migrate(client, dry_run=False)
         return
 
     # Add data
@@ -89,6 +91,7 @@ def set_db(client, data):
             )
 
     client.transact_write_items(TransactItems=items)
+    migrate(client, dry_run=False)
 
 
 class snapshot:
@@ -159,7 +162,6 @@ class TestFilmBot(unittest.TestCase):
             {
                 user_id1: User(
                     DiscordUserID=user_id1,
-                    NominatedFilmID=None,
                     VoteID=None,
                     AttendanceVoteID=None,
                 )
@@ -170,6 +172,7 @@ class TestFilmBot(unittest.TestCase):
         film_id = "fake-film-id"
         film_id2 = "fake-film-id2"
         guild2 = "second-guild"
+        d = datetime(2001, 1, 1, 5, 0, 0, 123)
         set_db(
             self.dynamodb_client,
             {
@@ -179,6 +182,16 @@ class TestFilmBot(unittest.TestCase):
                         "NominatedFilmID": film_id,
                         "VoteID": film_id2,
                         "AttendanceVoteID": None,
+                    },
+                    {
+                        "SK": f"FILM#NOMINATED#{film_id}",
+                        "FilmName": "Fake Film",
+                        "IMDbID": None,
+                        "DiscordUserID": user_id1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": None,
+                        "DateNominated": d.isoformat(),
                     },
                     {
                         "SK": f"DISCORDUSER#{user_id2}",
@@ -198,19 +211,26 @@ class TestFilmBot(unittest.TestCase):
             },
         )
 
+        # After migration: user1 gets film embedded; VoteID film_id2 has no
+        # FILM#NOMINATED# record so it's cleared. user2's VoteID film_id maps
+        # to user_id1 (nominator of film_id).
         self.assertEqual(
             filmbot.get_users(),
             {
                 user_id1: User(
                     DiscordUserID=user_id1,
-                    NominatedFilmID=film_id,
-                    VoteID=film_id2,
+                    VoteID=None,
                     AttendanceVoteID=None,
+                    FilmID=film_id,
+                    FilmName="Fake Film",
+                    IMDbID=None,
+                    CastVotes=0,
+                    AttendanceVotes=0,
+                    DateNominated=d,
                 ),
                 user_id2: User(
                     DiscordUserID=user_id2,
-                    NominatedFilmID=None,
-                    VoteID=film_id,
+                    VoteID=user_id1,
                     AttendanceVoteID=film_id2,
                 ),
             },
@@ -288,6 +308,39 @@ class TestFilmBot(unittest.TestCase):
                 "DateNominated": d.isoformat(),
             },
         ]
+        # DISCORDUSER# records so migration can embed film data
+        input_users = [
+            {
+                "SK": "DISCORDUSER#UserA",
+                "NominatedFilmID": "film1",
+                "VoteID": None,
+                "AttendanceVoteID": None,
+            },
+            {
+                "SK": "DISCORDUSER#UserB",
+                "NominatedFilmID": "film2",
+                "VoteID": None,
+                "AttendanceVoteID": None,
+            },
+            {
+                "SK": "DISCORDUSER#UserC",
+                "NominatedFilmID": "film3",
+                "VoteID": None,
+                "AttendanceVoteID": None,
+            },
+            {
+                "SK": "DISCORDUSER#UserD",
+                "NominatedFilmID": "film4",
+                "VoteID": None,
+                "AttendanceVoteID": None,
+            },
+            {
+                "SK": "DISCORDUSER#UserE",
+                "NominatedFilmID": "film5",
+                "VoteID": None,
+                "AttendanceVoteID": None,
+            },
+        ]
 
         expected = [
             Film(
@@ -351,7 +404,7 @@ class TestFilmBot(unittest.TestCase):
         # sorting the rows
         count = 0
         for input in permutations(input_films):
-            set_db(self.dynamodb_client, {guild: input})
+            set_db(self.dynamodb_client, {guild: list(input) + input_users})
 
             self.assertEqual(filmbot.get_nominations(), expected)
             count += 1
@@ -474,13 +527,20 @@ class TestFilmBot(unittest.TestCase):
             },
         ]
 
+        # After migration: VoteIDs (film IDs) are replaced with the nominator's
+        # Discord user ID. Film data is embedded in each DISCORDUSER# record.
         expected = [
             {
                 "User": User(
                     DiscordUserID="UserA",
-                    NominatedFilmID="film1",
-                    VoteID="film2",
+                    VoteID="UserB",  # voted for film2 → nominator is UserB
                     AttendanceVoteID=None,
+                    FilmID="film1",
+                    FilmName="FilmName1",
+                    IMDbID=None,
+                    CastVotes=0,
+                    AttendanceVotes=7,
+                    DateNominated=d,
                 ),
                 "Film": Film(
                     FilmID="film1",
@@ -497,9 +557,14 @@ class TestFilmBot(unittest.TestCase):
             {
                 "User": User(
                     DiscordUserID="UserB",
-                    NominatedFilmID="film2",
                     VoteID=None,
                     AttendanceVoteID=None,
+                    FilmID="film2",
+                    FilmName="FilmName2",
+                    IMDbID="0234567",
+                    CastVotes=3,
+                    AttendanceVotes=3,
+                    DateNominated=d,
                 ),
                 "Film": Film(
                     FilmID="film2",
@@ -516,9 +581,14 @@ class TestFilmBot(unittest.TestCase):
             {
                 "User": User(
                     DiscordUserID="UserD",
-                    NominatedFilmID="film4",
                     VoteID=None,
                     AttendanceVoteID=None,
+                    FilmID="film4",
+                    FilmName="FilmName4",
+                    IMDbID="03456789",
+                    CastVotes=2,
+                    AttendanceVotes=4,
+                    DateNominated=d,
                 ),
                 "Film": Film(
                     FilmID="film4",
@@ -535,9 +605,14 @@ class TestFilmBot(unittest.TestCase):
             {
                 "User": User(
                     DiscordUserID="UserE",
-                    NominatedFilmID="film5",
                     VoteID=None,
                     AttendanceVoteID=None,
+                    FilmID="film5",
+                    FilmName="FilmName5",
+                    IMDbID="04567890",
+                    CastVotes=2,
+                    AttendanceVotes=4,
+                    DateNominated=d + timedelta(seconds=1),
                 ),
                 "Film": Film(
                     FilmID="film5",
@@ -554,9 +629,14 @@ class TestFilmBot(unittest.TestCase):
             {
                 "User": User(
                     DiscordUserID="UserC",
-                    NominatedFilmID="film3",
-                    VoteID="film1",
+                    VoteID="UserA",  # voted for film1 → nominator is UserA
                     AttendanceVoteID=None,
+                    FilmID="film3",
+                    FilmName="FilmName3",
+                    IMDbID="0345678",
+                    CastVotes=2,
+                    AttendanceVotes=3,
+                    DateNominated=d,
                 ),
                 "Film": Film(
                     FilmID="film3",
@@ -573,8 +653,7 @@ class TestFilmBot(unittest.TestCase):
             {
                 "User": User(
                     DiscordUserID="UserF",
-                    NominatedFilmID=None,
-                    VoteID="film4",
+                    VoteID="UserD",  # voted for film4 → nominator is UserD
                     AttendanceVoteID=None,
                 ),
                 "Film": None,
@@ -582,7 +661,6 @@ class TestFilmBot(unittest.TestCase):
             {
                 "User": User(
                     DiscordUserID="UserG",
-                    NominatedFilmID=None,
                     VoteID=None,
                     AttendanceVoteID=None,
                 ),
@@ -622,6 +700,13 @@ class TestFilmBot(unittest.TestCase):
                 "AttendanceVotes": 2,
                 "UsersAttended": set(["A", "B", "C"]),
                 "DateNominated": (d - timedelta(seconds=10)).isoformat(),
+            },
+            {
+                # Nominated user should not appear in watched films
+                "SK": "DISCORDUSER#UserB",
+                "NominatedFilmID": "film2",
+                "VoteID": None,
+                "AttendanceVoteID": None,
             },
             {
                 "SK": "FILM#NOMINATED#film2",
@@ -748,6 +833,21 @@ class TestFilmBot(unittest.TestCase):
                 "DateNominated": (d + timedelta(seconds=3)).isoformat(),
             },
         ]
+        # DISCORDUSER# records so migration can embed film data for nominations
+        input_users = [
+            {
+                "SK": "DISCORDUSER#UserA",
+                "NominatedFilmID": "film1",
+                "VoteID": None,
+                "AttendanceVoteID": None,
+            },
+            {
+                "SK": "DISCORDUSER#UserB",
+                "NominatedFilmID": "film2",
+                "VoteID": None,
+                "AttendanceVoteID": None,
+            },
+        ]
 
         expected = [
             Film(
@@ -800,7 +900,7 @@ class TestFilmBot(unittest.TestCase):
         # sorting the rows
         count = 0
         for input in permutations(input_films):
-            set_db(self.dynamodb_client, {guild: input})
+            set_db(self.dynamodb_client, {guild: list(input) + input_users})
 
             self.assertEqual(filmbot.get_all_films(), expected)
             count += 1
@@ -831,19 +931,14 @@ class TestFilmBot(unittest.TestCase):
                 guild1: [
                     {
                         "SK": f"DISCORDUSER#{user_id1}",
-                        "NominatedFilmID": film_id1,
-                        "VoteID": None,
-                        "AttendanceVoteID": None,
-                    },
-                    {
-                        "SK": f"FILM#NOMINATED#{film_id1}",
+                        "FilmID": film_id1,
                         "FilmName": film_name1,
-                        "DiscordUserID": user_id1,
                         "IMDbID": imdb1,
                         "CastVotes": 0,
                         "AttendanceVotes": 0,
-                        "UsersAttended": None,
                         "DateNominated": time1.isoformat(),
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
                     },
                 ]
             },
@@ -876,52 +971,28 @@ class TestFilmBot(unittest.TestCase):
             guild1: [
                 {
                     "SK": f"DISCORDUSER#{user_id1}",
-                    "NominatedFilmID": film_id1,
+                    "FilmID": film_id1,
+                    "FilmName": film_name1,
+                    "IMDbID": imdb1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": time1.isoformat(),
                     "VoteID": None,
                     "AttendanceVoteID": None,
                 },
                 {
                     "SK": f"DISCORDUSER#{user_id2}",
-                    "NominatedFilmID": film_id2,
+                    "FilmID": film_id2,
+                    "FilmName": film_name2,
+                    "IMDbID": imdb2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": time2.isoformat(),
                     "VoteID": None,
                     "AttendanceVoteID": None,
                 },
-                {
-                    "SK": f"FILM#NOMINATED#{film_id1}",
-                    "FilmName": film_name1,
-                    "DiscordUserID": user_id1,
-                    "IMDbID": imdb1,
-                    "CastVotes": 0,
-                    "AttendanceVotes": 0,
-                    "UsersAttended": None,
-                    "DateNominated": time1.isoformat(),
-                },
-                {
-                    "SK": f"FILM#NOMINATED#{film_id2}",
-                    "FilmName": film_name2,
-                    "IMDbID": imdb2,
-                    "DiscordUserID": user_id2,
-                    "CastVotes": 0,
-                    "AttendanceVotes": 0,
-                    "UsersAttended": None,
-                    "DateNominated": time2.isoformat(),
-                },
             ]
         }
-        self.assertEqual(grab_db(self.dynamodb_client), expected)
-
-        # Check we can't reuse film IDs
-        user_id3 = "user3"
-        film_name3 = "My Film 3: The Return of The Unit Test"
-        imdb3 = "012343"
-        with self.assertRaises(UserError):
-            filmbot.nominate_film(
-                DiscordUserID=user_id3,
-                FilmName=film_name3,
-                IMDbID=imdb3,
-                NewFilmID=film_id1,
-                DateTime=time1,
-            )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         guild2 = "guild2"
@@ -942,53 +1013,38 @@ class TestFilmBot(unittest.TestCase):
                 guild1: [
                     {
                         "SK": f"DISCORDUSER#{user_id1}",
-                        "NominatedFilmID": film_id1,
+                        "FilmID": film_id1,
+                        "FilmName": film_name1,
+                        "IMDbID": imdb1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "DateNominated": time1.isoformat(),
                         "VoteID": None,
                         "AttendanceVoteID": None,
                     },
                     {
                         "SK": f"DISCORDUSER#{user_id2}",
-                        "NominatedFilmID": film_id2,
-                        "VoteID": None,
-                        "AttendanceVoteID": None,
-                    },
-                    {
-                        "SK": f"FILM#NOMINATED#{film_id1}",
-                        "FilmName": film_name1,
-                        "IMDbID": imdb1,
-                        "DiscordUserID": user_id1,
-                        "CastVotes": 0,
-                        "AttendanceVotes": 0,
-                        "UsersAttended": None,
-                        "DateNominated": time1.isoformat(),
-                    },
-                    {
-                        "SK": f"FILM#NOMINATED#{film_id2}",
+                        "FilmID": film_id2,
                         "FilmName": film_name2,
                         "IMDbID": imdb2,
-                        "DiscordUserID": user_id2,
                         "CastVotes": 0,
                         "AttendanceVotes": 0,
-                        "UsersAttended": None,
                         "DateNominated": time2.isoformat(),
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
                     },
                 ],
                 guild2: [
                     {
                         "SK": f"DISCORDUSER#{user_id1}",
-                        "NominatedFilmID": film_id1,
-                        "VoteID": None,
-                        "AttendanceVoteID": None,
-                    },
-                    {
-                        "SK": f"FILM#NOMINATED#{film_id1}",
+                        "FilmID": film_id1,
                         "FilmName": film_name1,
                         "IMDbID": imdb1,
-                        "DiscordUserID": user_id1,
                         "CastVotes": 0,
                         "AttendanceVotes": 0,
-                        "UsersAttended": None,
                         "DateNominated": time1.isoformat(),
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
                     },
                 ],
             },
@@ -1013,55 +1069,121 @@ class TestFilmBot(unittest.TestCase):
         film_watched = "Film4"
         d = datetime(2010, 1, 2, 3, 4, 5, 678)
         ages_ago = d - timedelta(days=100)
+
+        # Load old-schema data; migration runs inside set_db
+        set_db(
+            self.dynamodb_client,
+            {
+                guild1: [
+                    {
+                        "SK": f"DISCORDUSER#{user_id1}",
+                        "NominatedFilmID": film_id1,
+                        "VoteID": None,
+                        "AttendanceVoteID": "dummy",
+                    },
+                    {
+                        "SK": f"DISCORDUSER#{user_id2}",
+                        "NominatedFilmID": film_id2,
+                        "VoteID": None,
+                        "AttendanceVoteID": "dummy2",
+                    },
+                    {
+                        "SK": f"DISCORDUSER#{user_id3}",
+                        "NominatedFilmID": film_id3,
+                        "VoteID": None,
+                        "AttendanceVoteID": None,
+                    },
+                    {
+                        "SK": f"FILM#NOMINATED#{film_id1}",
+                        "FilmName": "My Film 1",
+                        "IMDbID": imdb1,
+                        "DiscordUserID": user_id1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": None,
+                        "DateNominated": d.isoformat(),
+                    },
+                    {
+                        "SK": f"FILM#NOMINATED#{film_id2}",
+                        "FilmName": "My Film 2",
+                        "IMDbID": imdb2,
+                        "DiscordUserID": user_id2,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": None,
+                        "DateNominated": d.isoformat(),
+                    },
+                    {
+                        "SK": f"FILM#NOMINATED#{film_id3}",
+                        "FilmName": "My Film 3",
+                        "IMDbID": imdb3,
+                        "DiscordUserID": user_id3,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": None,
+                        "DateNominated": d.isoformat(),
+                    },
+                    {
+                        "SK": f"FILM#WATCHED#{ages_ago.isoformat()}#Super-old-film",
+                        "FilmName": "My Film 4 (Watched)",
+                        "IMDbID": imdb4,
+                        "DiscordUserID": user_id1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": None,
+                        "DateNominated": ages_ago.isoformat(),
+                    },
+                    {
+                        "SK": f"FILM#WATCHED#{d.isoformat()}#{film_watched}",
+                        "FilmName": "My Film 5 (Watched)",
+                        "IMDbID": imdb5,
+                        "DiscordUserID": user_id1,
+                        "CastVotes": 0,
+                        "AttendanceVotes": 0,
+                        "UsersAttended": None,
+                        "DateNominated": d.isoformat(),
+                    },
+                ]
+            },
+        )
+
+        # Post-migration expected state: DISCORDUSER# records embed film data,
+        # FILM#NOMINATED# records are gone.
+        # Sorted by SK: DISCORDUSER#User1 < User2 < User3 < FILM#WATCHED#{ages_ago}... < FILM#WATCHED#{d}...
         expected = {
             guild1: [
                 {
                     "SK": f"DISCORDUSER#{user_id1}",
-                    "NominatedFilmID": film_id1,
+                    "FilmID": film_id1,
+                    "FilmName": "My Film 1",
+                    "IMDbID": imdb1,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": d.isoformat(),
                     "VoteID": None,
                     "AttendanceVoteID": "dummy",
                 },
                 {
                     "SK": f"DISCORDUSER#{user_id2}",
-                    "NominatedFilmID": film_id2,
+                    "FilmID": film_id2,
+                    "FilmName": "My Film 2",
+                    "IMDbID": imdb2,
+                    "CastVotes": 0,
+                    "AttendanceVotes": 0,
+                    "DateNominated": d.isoformat(),
                     "VoteID": None,
                     "AttendanceVoteID": "dummy2",
                 },
                 {
                     "SK": f"DISCORDUSER#{user_id3}",
-                    "NominatedFilmID": None,
-                    "VoteID": None,
-                    "AttendanceVoteID": None,
-                },
-                {
-                    "SK": f"FILM#NOMINATED#{film_id1}",
-                    "FilmName": "My Film 1",
-                    "IMDbID": imdb1,
-                    "DiscordUserID": user_id1,
-                    "CastVotes": 0,
-                    "AttendanceVotes": 0,
-                    "UsersAttended": None,
-                    "DateNominated": d.isoformat(),
-                },
-                {
-                    "SK": f"FILM#NOMINATED#{film_id2}",
-                    "FilmName": "My Film 2",
-                    "IMDbID": imdb2,
-                    "DiscordUserID": user_id2,
-                    "CastVotes": 0,
-                    "AttendanceVotes": 0,
-                    "UsersAttended": None,
-                    "DateNominated": d.isoformat(),
-                },
-                {
-                    "SK": f"FILM#NOMINATED#{film_id3}",
+                    "FilmID": film_id3,
                     "FilmName": "My Film 3",
                     "IMDbID": imdb3,
-                    "DiscordUserID": "dummy",
                     "CastVotes": 0,
                     "AttendanceVotes": 0,
-                    "UsersAttended": None,
                     "DateNominated": d.isoformat(),
+                    "VoteID": None,
+                    "AttendanceVoteID": None,
                 },
                 {
                     "SK": f"FILM#WATCHED#{ages_ago.isoformat()}#Super-old-film",
@@ -1086,57 +1208,45 @@ class TestFilmBot(unittest.TestCase):
             ]
         }
 
-        # Create indices into `expected` that we can use later on
+        # Indices into `expected`
         USER_1 = 0
         USER_2 = 1
         USER_3 = 2
-        FILM_1 = 3
-        FILM_2 = 4
-        FILM_3 = 5
 
-        # Set up the database
-        set_db(self.dynamodb_client, expected)
         self.assertEqual(grab_db(self.dynamodb_client), expected)
         filmbot = FilmBot(DynamoDBClient=self.dynamodb_client, GuildID=guild1)
 
         # Check we can't vote if we're not registered
         with self.assertRaises(UserError):
             filmbot.cast_preference_vote(
-                DiscordUserID="not registered", FilmID=film_id1
+                DiscordUserID="not registered", NominatorUserID=user_id1
             )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check we can't vote for an already watched film
+        # Check we can't vote for a user without a nomination
         with self.assertRaises(UserError):
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id1, FilmID=film_watched
-            )
-        self.assertEqual(grab_db(self.dynamodb_client), expected)
-
-        # Check we can't vote for a non-existent film
-        with self.assertRaises(UserError):
-            filmbot.cast_preference_vote(
-                DiscordUserID=user_id1, FilmID="not existent"
+                DiscordUserID=user_id1, NominatorUserID="not existent"
             )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         # Check we can vote with no previous vote
         self.assertEqual(
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id1, FilmID=film_id2
-            ),
+                DiscordUserID=user_id1, NominatorUserID=user_id2
+            )[0],
             VotingStatus.UNCOMPLETE,
         )
 
-        expected[guild1][FILM_2]["CastVotes"] += 1
-        expected[guild1][USER_1]["VoteID"] = film_id2
+        expected[guild1][USER_2]["CastVotes"] += 1
+        expected[guild1][USER_1]["VoteID"] = user_id2
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check we can vote for the same film as it's a shortcut path in the code
+        # Check we can vote for the same user again (shortcut path in the code)
         self.assertEqual(
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id1, FilmID=film_id2
-            ),
+                DiscordUserID=user_id1, NominatorUserID=user_id2
+            )[0],
             VotingStatus.UNCOMPLETE,
         )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
@@ -1144,60 +1254,60 @@ class TestFilmBot(unittest.TestCase):
         # Check we can change our vote
         self.assertEqual(
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id1, FilmID=film_id3
-            ),
+                DiscordUserID=user_id1, NominatorUserID=user_id3
+            )[0],
             VotingStatus.UNCOMPLETE,
         )
-        expected[guild1][FILM_2]["CastVotes"] -= 1
-        expected[guild1][FILM_3]["CastVotes"] += 1
-        expected[guild1][USER_1]["VoteID"] = film_id3
+        expected[guild1][USER_2]["CastVotes"] -= 1
+        expected[guild1][USER_3]["CastVotes"] += 1
+        expected[guild1][USER_1]["VoteID"] = user_id3
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check we can't vote for our nomination
+        # Check we can't vote for our own nomination
         with self.assertRaises(UserError):
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id1, FilmID=film_id1
+                DiscordUserID=user_id1, NominatorUserID=user_id1
             ),
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         # Check that we know when voting is finished
         self.assertEqual(
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id2, FilmID=film_id1
-            ),
+                DiscordUserID=user_id2, NominatorUserID=user_id1
+            )[0],
             VotingStatus.UNCOMPLETE,
         )
-        expected[guild1][FILM_1]["CastVotes"] += 1
-        expected[guild1][USER_2]["VoteID"] = film_id1
+        expected[guild1][USER_1]["CastVotes"] += 1
+        expected[guild1][USER_2]["VoteID"] = user_id1
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         self.assertEqual(
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id3, FilmID=film_id1
-            ),
+                DiscordUserID=user_id3, NominatorUserID=user_id1
+            )[0],
             VotingStatus.COMPLETE,
         )
-        expected[guild1][FILM_1]["CastVotes"] += 1
-        expected[guild1][USER_3]["VoteID"] = film_id1
+        expected[guild1][USER_1]["CastVotes"] += 1
+        expected[guild1][USER_3]["VoteID"] = user_id1
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
         # Check that we can change votes when voting is finished
         self.assertEqual(
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id3, FilmID=film_id2
-            ),
+                DiscordUserID=user_id3, NominatorUserID=user_id2
+            )[0],
             VotingStatus.COMPLETE,
         )
-        expected[guild1][FILM_1]["CastVotes"] -= 1
-        expected[guild1][FILM_2]["CastVotes"] += 1
-        expected[guild1][USER_3]["VoteID"] = film_id2
+        expected[guild1][USER_1]["CastVotes"] -= 1
+        expected[guild1][USER_2]["CastVotes"] += 1
+        expected[guild1][USER_3]["VoteID"] = user_id2
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check we can vote for the same film once voting is finished
+        # Check we can vote for the same user once voting is finished
         self.assertEqual(
             filmbot.cast_preference_vote(
-                DiscordUserID=user_id3, FilmID=film_id2
-            ),
+                DiscordUserID=user_id3, NominatorUserID=user_id2
+            )[0],
             VotingStatus.COMPLETE,
         )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
@@ -1205,19 +1315,10 @@ class TestFilmBot(unittest.TestCase):
         good_time = d + timedelta(hours=24)
         bad_time = good_time - timedelta(seconds=1)
 
-        # Check that we can't watch a film that doesn't exist
+        # Check that we can't watch a film for a non-existent user
         with self.assertRaises(UserError):
             filmbot.start_watching_film(
-                FilmID="non existent",
-                DateTime=good_time,
-                PresentUserIDs=[user_id1],
-            )
-        self.assertEqual(grab_db(self.dynamodb_client), expected)
-
-        # Check that we can't watch a film that has already been watched
-        with self.assertRaises(UserError):
-            filmbot.start_watching_film(
-                FilmID=film_watched,
+                NominatorUserID="non existent",
                 DateTime=good_time,
                 PresentUserIDs=[user_id1],
             )
@@ -1226,7 +1327,9 @@ class TestFilmBot(unittest.TestCase):
         # Check we can't watch another film within 24 hours
         with self.assertRaises(UserError):
             filmbot.start_watching_film(
-                FilmID=film_id1, DateTime=bad_time, PresentUserIDs=[user_id1]
+                NominatorUserID=user_id1,
+                DateTime=bad_time,
+                PresentUserIDs=[user_id1],
             )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
@@ -1234,7 +1337,7 @@ class TestFilmBot(unittest.TestCase):
         with snapshot(self.dynamodb_client) as exp:
             self.assertEqual(
                 filmbot.start_watching_film(
-                    FilmID=film_id1,
+                    NominatorUserID=user_id1,
                     DateTime=good_time,
                     PresentUserIDs=[user_id1, user_id2, user_id3],
                 ),
@@ -1251,32 +1354,46 @@ class TestFilmBot(unittest.TestCase):
                 ),
             )
 
-            # Update our users
-            exp[guild1][USER_1]["NominatedFilmID"] = None
+            # User1's film fields removed, VoteID/AttendanceVoteID updated
+            del exp[guild1][USER_1]["FilmID"]
+            del exp[guild1][USER_1]["FilmName"]
+            del exp[guild1][USER_1]["IMDbID"]
+            del exp[guild1][USER_1]["CastVotes"]
+            del exp[guild1][USER_1]["AttendanceVotes"]
+            del exp[guild1][USER_1]["DateNominated"]
             exp[guild1][USER_1]["VoteID"] = None
             exp[guild1][USER_1]["AttendanceVoteID"] = film_id1
+
+            # User2 present, not nominator, has film2 → AttendanceVotes increments
             exp[guild1][USER_2]["VoteID"] = None
             exp[guild1][USER_2]["AttendanceVoteID"] = film_id1
+            exp[guild1][USER_2]["AttendanceVotes"] += 1
+
+            # User3 present, not nominator, has film3 → AttendanceVotes increments
             exp[guild1][USER_3]["VoteID"] = None
             exp[guild1][USER_3]["AttendanceVoteID"] = film_id1
+            exp[guild1][USER_3]["AttendanceVotes"] += 1
 
-            # Update our nomination votes for user2 (user1 nominated the watched
-            # film and user3 has no nomination)
-            exp[guild1][FILM_2]["AttendanceVotes"] += 1
-
-            # Move the film to the `WATCHED` section
-            watched_film = exp[guild1].pop(FILM_1)
-            watched_film["SK"] = (
-                f"FILM#WATCHED#{good_time.isoformat()}#{film_id1}"
+            exp[guild1].append(
+                {
+                    "SK": f"FILM#WATCHED#{good_time.isoformat()}#{film_id1}",
+                    "FilmName": "My Film 1",
+                    "IMDbID": imdb1,
+                    "DiscordUserID": user_id1,
+                    "CastVotes": 1,
+                    "AttendanceVotes": 0,
+                    "UsersAttended": set([user_id1, user_id2, user_id3]),
+                    "DateNominated": d.isoformat(),
+                }
             )
-            watched_film["UsersAttended"] = set([user_id1, user_id2, user_id3])
-            exp[guild1].append(watched_film)
             self.assertEqual(grab_db(self.dynamodb_client), exp)
 
         # Check we can watch a film with just one user
         self.assertEqual(
             filmbot.start_watching_film(
-                FilmID=film_id1, DateTime=good_time, PresentUserIDs=[user_id1]
+                NominatorUserID=user_id1,
+                DateTime=good_time,
+                PresentUserIDs=[user_id1],
             ),
             Film(
                 FilmID=film_id1,
@@ -1291,29 +1408,46 @@ class TestFilmBot(unittest.TestCase):
             ),
         )
 
-        # Update our users
-        expected[guild1][USER_1]["NominatedFilmID"] = None
+        # User1 film fields cleared, present → AttendanceVoteID set
+        del expected[guild1][USER_1]["FilmID"]
+        del expected[guild1][USER_1]["FilmName"]
+        del expected[guild1][USER_1]["IMDbID"]
+        del expected[guild1][USER_1]["CastVotes"]
+        del expected[guild1][USER_1]["AttendanceVotes"]
+        del expected[guild1][USER_1]["DateNominated"]
         expected[guild1][USER_1]["VoteID"] = None
         expected[guild1][USER_1]["AttendanceVoteID"] = film_id1
+        # User2 not present: vote and attendance cleared
         expected[guild1][USER_2]["VoteID"] = None
         expected[guild1][USER_2]["AttendanceVoteID"] = None
+        # User3 not present: vote cleared
         expected[guild1][USER_3]["VoteID"] = None
 
-        # Move the film to the `WATCHED` section
-        watched_film = expected[guild1].pop(FILM_1)
-        watched_film["SK"] = f"FILM#WATCHED#{good_time.isoformat()}#{film_id1}"
-        watched_film["UsersAttended"] = set([user_id1])
-        expected[guild1].append(watched_film)
+        expected[guild1].append(
+            {
+                "SK": f"FILM#WATCHED#{good_time.isoformat()}#{film_id1}",
+                "FilmName": "My Film 1",
+                "IMDbID": imdb1,
+                "DiscordUserID": user_id1,
+                "CastVotes": 1,
+                "AttendanceVotes": 0,
+                "UsersAttended": set([user_id1]),
+                "DateNominated": d.isoformat(),
+            }
+        )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Fixup the indices
+        # After watching: list is now 5 items sorted by SK:
+        # 0: DISCORDUSER#User1 (no film fields)
+        # 1: DISCORDUSER#User2 (has film2)
+        # 2: DISCORDUSER#User3 (has film3)
+        # 3: FILM#WATCHED#{ages_ago}#Super-old-film
+        # 4: FILM#WATCHED#{d}#Film4
+        # 5: FILM#WATCHED#{good_time}#Film1
         USER_1 = 0
         USER_2 = 1
         USER_3 = 2
-        FILM_2 = 3
-        FILM_3 = 4
-        FILM_1 = 7
-        self.assertEqual(grab_db(self.dynamodb_client), expected)
+        FILM_1 = 5
 
         # Check we can't record attendance before the film is watched
         too_early = good_time - timedelta(seconds=1)
@@ -1332,7 +1466,7 @@ class TestFilmBot(unittest.TestCase):
             )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check we recording attendance for the nominator is a noop
+        # Check that recording attendance for user1 (already marked present) is a noop
         self.assertEqual(
             filmbot.record_attendance_vote(
                 DiscordUserID=user_id1, DateTime=good_time
@@ -1341,8 +1475,7 @@ class TestFilmBot(unittest.TestCase):
         )
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check we can record attendance on the cut off with a user
-        # who has a nominated film
+        # Check we can record attendance on the cutoff with a user who has a film
         just_in_time = good_time + timedelta(hours=4)
         self.assertEqual(
             filmbot.record_attendance_vote(
@@ -1352,10 +1485,10 @@ class TestFilmBot(unittest.TestCase):
         )
         expected[guild1][USER_2]["AttendanceVoteID"] = film_id1
         expected[guild1][FILM_1]["UsersAttended"].add(user_id2)
-        expected[guild1][FILM_2]["AttendanceVotes"] += 1
+        expected[guild1][USER_2]["AttendanceVotes"] += 1
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
-        # Check we can record attendance for a user with no nominated film
+        # Check we can record attendance for a user who has a nominated film (user3)
         self.assertEqual(
             filmbot.record_attendance_vote(
                 DiscordUserID=user_id3, DateTime=just_in_time
@@ -1364,6 +1497,7 @@ class TestFilmBot(unittest.TestCase):
         )
         expected[guild1][USER_3]["AttendanceVoteID"] = film_id1
         expected[guild1][FILM_1]["UsersAttended"].add(user_id3)
+        expected[guild1][USER_3]["AttendanceVotes"] += 1
         self.assertEqual(grab_db(self.dynamodb_client), expected)
 
     def test_retire_user(self):
@@ -1509,6 +1643,9 @@ class TestFilmBot(unittest.TestCase):
         }
         set_db(self.dynamodb_client, eligible_data)
 
+        # After migration: VoteIDs film_id1 → user_id1 for user2 and user3.
+        # FILM#NOMINATED# records are deleted; film data is embedded in DISCORDUSER#.
+
         # user3: no nomination, no vote, no recent attendance
         self.assertIsNone(filmbot.can_retire(DiscordUserID=user_id3))
         filmbot.retire_user(DiscordUserID=user_id3)
@@ -1517,22 +1654,18 @@ class TestFilmBot(unittest.TestCase):
         self.assertNotIn(f"DISCORDUSER#{user_id3}", user_sks)
         self.assertIn(f"DISCORDUSER#{user_id1}", user_sks)
         self.assertIn(f"DISCORDUSER#{user_id2}", user_sks)
-        self.assertIn(f"FILM#NOMINATED#{film_id1}", user_sks)
-        self.assertIn(f"FILM#NOMINATED#{film_id2}", user_sks)
 
-        # user1: no vote, no one has voted for their film, no recent attendance
-        # Retiring user1 removes their DISCORDUSER# record and their FILM#NOMINATED# record
+        # user1: no vote, no one has voted for their film, no recent attendance.
+        # Retiring user1 removes DISCORDUSER#user1 (which contains their film data).
         self.assertIsNone(filmbot.can_retire(DiscordUserID=user_id1))
         filmbot.retire_user(DiscordUserID=user_id1)
         db = grab_db(self.dynamodb_client)
         user_sks = [r["SK"] for r in db[guild]]
         self.assertNotIn(f"DISCORDUSER#{user_id1}", user_sks)
-        self.assertNotIn(f"FILM#NOMINATED#{film_id1}", user_sks)
         self.assertIn(f"DISCORDUSER#{user_id2}", user_sks)
-        self.assertIn(f"FILM#NOMINATED#{film_id2}", user_sks)
 
         # CastVotes > 0 from a previous round should not block retirement when no
-        # user currently has VoteID pointing at the film.
+        # user currently has VoteID pointing at user2.
         # user2 has CastVotes=3 (leftover from old rounds) but no live voters.
         set_db(
             self.dynamodb_client,
@@ -1572,7 +1705,6 @@ class TestFilmBot(unittest.TestCase):
         db = grab_db(self.dynamodb_client)
         user_sks = [r["SK"] for r in db[guild]]
         self.assertNotIn(f"DISCORDUSER#{user_id2}", user_sks)
-        self.assertNotIn(f"FILM#NOMINATED#{film_id2}", user_sks)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Our current schema is a bit too relational and we end up having to cross reference film data with the users nominations.  This leads to strange situations where we have a range where we search for nominated films and users in one query, precluding us from adding any other SK between them alphabetically.

This change embeds the nominated film information inside the user records.  This simplifies our query for the current set of nominations and is more idiomatic for DynamoDB.

We include a script to migrate the database schema.  Unit tests have been updated to run this migration script on the set up data.  Once this change has been pushed and verified to be okay, we can update the unit tests not to use the migration script and instead hardcode the input data in the new schema format.

Warning: We need to run the migration script before this change lands and automatically deploys.