### PR TITLE
Automatically record watchers

### DIFF
--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -73,6 +73,39 @@ def _tmdb_headers():
     return {"Authorization": f"Bearer {os.environ.get('TMDB_TOKEN')}"}
 
 
+def _discord_headers():
+    return {"Authorization": f"Bot {os.environ.get('DISCORD_BOT_TOKEN')}"}
+
+
+def _get_voice_channel_member_ids(guild_id, user_id):
+    """Return IDs of all users in the same voice channel as user_id, or None if not in one or on error."""
+    try:
+        DISCORD_API = "https://discord.com/api/v10"
+        r = requests.get(
+            f"{DISCORD_API}/guilds/{guild_id}/voice-states",
+            headers=_discord_headers(),
+        )
+        r.raise_for_status()
+        voice_states = r.json()
+        channel_id = next(
+            (
+                vs["channel_id"]
+                for vs in voice_states
+                if vs.get("user_id") == user_id
+            ),
+            None,
+        )
+        if channel_id is None:
+            return None
+        return [
+            vs["user_id"]
+            for vs in voice_states
+            if vs.get("channel_id") == channel_id
+        ]
+    except Exception:
+        return None
+
+
 def encode_TMDB(tmdb_id, film_name_with_year):
     return f"TMDB:{tmdb_id}:{film_name_with_year}"
 
@@ -325,17 +358,23 @@ def handle_application_command(event, client):
 
     elif command == "watch":
         nominator_id = body["data"]["options"][0]["value"]
-        film = filmbot.start_watching_film(
+        voice_user_ids = _get_voice_channel_member_ids(guild_id, user_id)
+        present_user_ids = (
+            voice_user_ids if voice_user_ids is not None else [user_id]
+        )
+        film, recorded_user_ids = filmbot.start_watching_film(
             NominatorUserID=nominator_id,
             DateTime=now,
-            PresentUserIDs=[user_id],
+            PresentUserIDs=present_user_ids,
         )
+        recorded_mentions = " ".join(f"<@{uid}>" for uid in recorded_user_ids)
         return {
             "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
             "data": {
                 "content": (
                     f"Started watching {film.FilmName}!\n\n"
-                    + f"Everyone other than <@{user_id}> should record their attendance below or using `/here`.\n\n"
+                    + f"Recorded attendance for: {recorded_mentions}\n\n"
+                    + f"Anyone else should record their attendance below or using `/here`.\n\n"
                     + f"<@{film.DiscordUserID}> can now nominated their next suggestion with `/nominate`.\n"
                 ),
                 "components": [

--- a/discord_handler/filmbot.py
+++ b/discord_handler/filmbot.py
@@ -663,11 +663,13 @@ class FilmBot:
     ):
         """
         Attempt to record that we're watching the film nominated by `NominatorUserID`
-        and record an attendance vote for each user in the `PresentUserIDs` array
-        and return the a `Film` object.  Also clear out all cast votes from all users
-        and clear the nomination from the user who nominated the film.  Throw an
-        exception if `NominatorUserID` doesn't have an active nomination, less than
-        24 hours has passed since watching the last film, or `PresentUserIDs` is empty.
+        and record an attendance vote for each user in the `PresentUserIDs` array.
+        Returns a `(Film, list[DiscordUserID])` tuple where the second element is the
+        subset of `PresentUserIDs` that had existing records and were actually updated.
+        Also clears out all cast votes from all users and clears the nomination from the
+        user who nominated the film.  Throws an exception if `NominatorUserID` doesn't
+        have an active nomination, less than 24 hours has passed since watching the last
+        film, or `PresentUserIDs` is empty.
         """
 
         # At least one user must be present to start watching a film
@@ -692,10 +694,8 @@ class FilmBot:
                 f"There is no film nominated by <@{NominatorUserID}>"
             )
 
-        # Check to see all user IDs are valid
         all_users = self.get_users()
-        for user in PresentUserIDs:
-            assert user in all_users
+        PresentUserIDs = [uid for uid in PresentUserIDs if uid in all_users]
 
         film = _user_to_film(nominator_user)
 
@@ -775,7 +775,9 @@ class FilmBot:
                 condition = "FilmID = :PreviousFilmID"
                 expr_attr_values[":PreviousFilmID"] = {"S": user.FilmID}
             else:
-                condition = "attribute_not_exists(FilmName)"
+                condition = (
+                    "attribute_exists(SK) AND attribute_not_exists(FilmName)"
+                )
 
             items.append(
                 {
@@ -804,7 +806,7 @@ class FilmBot:
         )
         self.client.transact_write_items(TransactItems=items)
 
-        return film
+        return film, PresentUserIDs
 
     def _check_retire(self, *, DiscordUserID):
         """
@@ -1027,8 +1029,8 @@ class FilmBot:
                         USER_SK: {"S": user.SK},
                     },
                     "ExpressionAttributeValues": expr_attr_values,
-                    # Check that we haven't recorded an attendance in the meantime
-                    "ConditionExpression": f"{USER_AttendanceVoteID} = :Null",
+                    # Check that the user record still exists and we haven't recorded an attendance in the meantime
+                    "ConditionExpression": f"attribute_exists(SK) AND {USER_AttendanceVoteID} = :Null",
                     "UpdateExpression": update_expr,
                 }
             },

--- a/discord_handler/test_discord_handler.py
+++ b/discord_handler/test_discord_handler.py
@@ -568,7 +568,8 @@ class TestDiscordHandler(unittest.TestCase):
                 "type": DiscordResponse.CHANNEL_MESSAGE_WITH_SOURCE,
                 "data": {
                     "content": "Started watching My Film Name!\n\n"
-                    + "Everyone other than <@def> should record their attendance below or using `/here`.\n\n"
+                    + "Recorded attendance for: <@def>\n\n"
+                    + "Anyone else should record their attendance below or using `/here`.\n\n"
                     + "<@abc> can now nominated their next suggestion with `/nominate`.\n",
                     "components": [
                         {

--- a/discord_handler/test_filmbot.py
+++ b/discord_handler/test_filmbot.py
@@ -1335,12 +1335,13 @@ class TestFilmBot(unittest.TestCase):
 
         # Check we can watch a film with multiple users initially present
         with snapshot(self.dynamodb_client) as exp:
+            film, recorded = filmbot.start_watching_film(
+                NominatorUserID=user_id1,
+                DateTime=good_time,
+                PresentUserIDs=[user_id1, user_id2, user_id3],
+            )
             self.assertEqual(
-                filmbot.start_watching_film(
-                    NominatorUserID=user_id1,
-                    DateTime=good_time,
-                    PresentUserIDs=[user_id1, user_id2, user_id3],
-                ),
+                film,
                 Film(
                     FilmID=film_id1,
                     FilmName="My Film 1",
@@ -1353,6 +1354,7 @@ class TestFilmBot(unittest.TestCase):
                     DateWatched=good_time,
                 ),
             )
+            self.assertEqual(set(recorded), {user_id1, user_id2, user_id3})
 
             # User1's film fields removed, VoteID/AttendanceVoteID updated
             del exp[guild1][USER_1]["FilmID"]
@@ -1389,12 +1391,13 @@ class TestFilmBot(unittest.TestCase):
             self.assertEqual(grab_db(self.dynamodb_client), exp)
 
         # Check we can watch a film with just one user
+        film, recorded = filmbot.start_watching_film(
+            NominatorUserID=user_id1,
+            DateTime=good_time,
+            PresentUserIDs=[user_id1],
+        )
         self.assertEqual(
-            filmbot.start_watching_film(
-                NominatorUserID=user_id1,
-                DateTime=good_time,
-                PresentUserIDs=[user_id1],
-            ),
+            film,
             Film(
                 FilmID=film_id1,
                 FilmName="My Film 1",
@@ -1407,6 +1410,7 @@ class TestFilmBot(unittest.TestCase):
                 DateWatched=good_time,
             ),
         )
+        self.assertEqual(recorded, [user_id1])
 
         # User1 film fields cleared, present → AttendanceVoteID set
         del expected[guild1][USER_1]["FilmID"]


### PR DESCRIPTION
When this bot was originally written, there was not a simple way to look at the members of a particular channel, without subscribing to all users connecting and disconnecting.

This has since change and we can get a list of the users who are in the same channel as the user who typed `/watch`.  These can be added as the initial list of users to mark as attended.

As users can now be retired, there is an additional check we need to make in the transaction, that the attending user has not been retired (i.e. the record still exists).