### PR TITLE
Sort autocomplete by votes

### DIFF
--- a/discord_handler/discord_handler.py
+++ b/discord_handler/discord_handler.py
@@ -464,6 +464,12 @@ def handle_autocomplete(event, client):
         )
         r.raise_for_status()
         results = r.json()["results"][:MAX_RESULTS]
+        title_order = {}
+        for m in results:
+            title_order.setdefault(m["title"], len(title_order))
+        results.sort(
+            key=lambda m: (title_order[m["title"]], -m.get("vote_count", 0))
+        )
         return {
             "type": DiscordResponse.APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
             "data": {


### PR DESCRIPTION
There are films with the same name and release date, which makes them indistinguishable from each other in the autocomplete. Our example was [Teeth (2007)](https://www.imdb.com/title/tt0780622/) and the short film [Teeth (2007)](https://www.imdb.com/title/tt1018942/) .  In this situation, we order them by the number of votes, which should give users the more likely film as the first suggestion.

There are other alternatives (such as showing runtime in the autcomplete), but this would require additional requests and this is a very unlikely conflict to start with.